### PR TITLE
Use multiple entity manager in one environment

### DIFF
--- a/Form/Type/TranslationsType.php
+++ b/Form/Type/TranslationsType.php
@@ -30,7 +30,7 @@ class TranslationsType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $translatableConfig = $this->translationForm->initTranslatableConfiguration($builder->getParent()->getDataClass());
+        $translatableConfig = $this->translationForm->initTranslatableConfiguration($builder->getParent()->getDataClass(), $options['entity_manager']);
         $childrenOptions = $this->translationForm->getChildrenOptions($options);
 
         $builder->setDataMapper(new TranslationMapper($translatableConfig['translationClass']));
@@ -55,7 +55,8 @@ class TranslationsType extends AbstractType
         $resolver->setDefaults(array(
             'locales' => $this->locales,
             'required' => $this->required,
-            'fields' => array()
+            'fields' => array(), 
+            'entity_manager' => null,
         ));
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="form.registry" />
             <argument type="service" id="a2lix_translation_form.object_manager" />
             <argument type="service" id="stof_doctrine_extensions.listener.translatable" />
+            <argument type="service" id="doctrine" />
         </service>
         <service id="form.type.translations" class="%a2lix_translation_form.translations.type.class%">
             <argument type="service" id="a2lix_translation_form.translation" />

--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -5,6 +5,7 @@ namespace A2lix\TranslationFormBundle\TranslationForm;
 use Symfony\Component\Form\FormRegistry,
     Doctrine\Common\Persistence\ObjectManager,
     Gedmo\Translatable\TranslatableListener;
+use Doctrine\Bundle\DoctrineBundle\Registry;
 
 /**
  * @author David ALLIX
@@ -15,17 +16,23 @@ class TranslationForm
     private $om;
     private $translatableListener;
     private $translatableConfig = array();
+    private $doctrine;
 
-    public function __construct(FormRegistry $formRegistry, ObjectManager $om, TranslatableListener $translatableListener)
+    public function __construct(FormRegistry $formRegistry, ObjectManager $om, TranslatableListener $translatableListener, Registry $doctrine)
     {
         $this->guesser = $formRegistry->getTypeGuesser();
         $this->om = $om;
         $this->translatableListener = $translatableListener;
+        $this->doctrine = $doctrine;
     }
 
-    public function initTranslatableConfiguration($class)
+    public function initTranslatableConfiguration($class, $entity_manager)
     {
+      if($entity_manager == null){
         return $this->translatableConfig = $this->translatableListener->getConfiguration($this->om, $class);
+      }else{
+        return $this->translatableConfig = $this->translatableListener->getConfiguration($this->doctrine->getManager($entity_manager), $class);
+      }
     }
 
     public function getDistinctLocales($locales)


### PR DESCRIPTION
As the title says, now you can use multiple entity managers in one environment. This is done by adding the form option 'entity_manager' which defaults to null. When null, the value from config.yml is used. 
