### PR TITLE
Form collection with translations throw FatalError on GedmoTranslationMapper

### DIFF
--- a/Form/DataMapper/GedmoTranslationMapper.php
+++ b/Form/DataMapper/GedmoTranslationMapper.php
@@ -64,9 +64,9 @@ class GedmoTranslationMapper implements DataMapperInterface
             $locale = $translationsFieldsForm->getConfig()->getName();
 
             foreach ($translationsFieldsForm->getData() as $field => $content) {
-                $existingTranslation = $data->filter(function($object) use ($locale, $field) {
+                $existingTranslation = $data ? $data->filter(function($object) use ($locale, $field) {
                     return ($object && ($object->getLocale() === $locale) && ($object->getField() === $field));
-                })->first();
+                })->first() : null;
 
                 if ($existingTranslation) {
                     $existingTranslation->setContent($content);


### PR DESCRIPTION
Hi,

when I try to save a form with one collection of another entity with translations, the GedmoTranslationMapper throws this error: 

FatalErrorException: Error: Call to a member function filter() on a non-object in /vendor/a2lix/translation-form-bundle/A2lix/TranslationFormBundle/Form/DataMapper/GedmoTranslationMapper.php line 67,

because the $data variable is a empty array.

This error appears on execute $form->bind($request);
The $request is ok with all data sent correctly

before update to symfony 2.3 and update your bundle everything worked correctly.

this is a bug of new version? or a bad implementation of this bundle?

Thank's!
