### PR TITLE
Updated default.html.twig for twitter Bootstrap compatibility

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -4,8 +4,8 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <li {% if (app.request.locale == locale) %}class="active"{% endif %} data-toggle="tab">
-                <a href=".a2lix_translationsFields-{{ locale }}">
+            <li {% if (app.request.locale == locale) %}class="active"{% endif %}>
+                <a href=".a2lix_translationsFields-{{ locale }}" data-toggle="tab">
                    {{ locale|capitalize }}
                 </a>
             </li>
@@ -33,8 +33,8 @@
             {% for translationsFields in translationsLocales %}
                 {% set locale = translationsFields.vars.name %}
 
-                <li {% if (app.request.locale == locale) %}class="active"{% endif %} data-toggle="tab">
-                    <a href=".a2lix_translationsFields-{{ locale }}">
+                <li {% if (app.request.locale == locale) %}class="active"{% endif %}>
+                    <a href=".a2lix_translationsFields-{{ locale }}" data-toggle="tab">
                         {{ locale|capitalize }} {% if isDefaultLocale %}[Default]{% endif %}
                     </a>
                 </li>


### PR DESCRIPTION
According to twitter Bootstrap documentation, the toggable tags markup
need to have the data-toggle="tab" attribute in the "a" element and
not in its "li" parent.

See http://twitter.github.io/bootstrap/javascript.html#tabs

The data-toggle attribute has been moved accordingly.
