### PR TITLE
Added missing ,

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ $builder
                 **OTHER_OPTIONS**               // [optional] max_length, required, trim, read_only, constraints, ...
             ),
             'description' => array(
-                'label' => 'Desc.'              // [optional]
+                'label' => 'Desc.',              // [optional]
                 'locale_options' => array(              // [optional] Manual configuration of field for a dedicated locale -- Higher priority
                     'es' => array(
                         'label' => 'descripción'        // [optional] Higher priority


### PR DESCRIPTION
Added missing , in:
$builder
    ->add('translations', 'a2lix_translations', array(
        'locales' => array('fr', 'es', 'de'),   // [optional|required - depends on the presence in config.yml] See above
        'required' => true,                     // [optional] Overrides default_required if need
        'fields' => array(                      // [optional] Manual configuration of fields to display and options. If not specified, all translatable fields will be display, and options will be auto-detected
            'title' => array(
                'label' => 'name',              // [optional] Custom label. Ucfirst, otherwise
                'type' => 'textarea',           // [optional] Custom type
                **OTHER_OPTIONS**               // [optional] max_length, required, trim, read_only, constraints, ...
            ),
            'description' => array(
                'label' => 'Desc.',              // [optional]
                'locale_options' => array(              // [optional] Manual configuration of field for a dedicated locale -- Higher priority
                    'es' => array(
                        'label' => 'descripción'        // [optional] Higher priority
                        **OTHER_OPTIONS**               // [optional] Same possibilities as above
                    ),
                    'fr' => array(
                        'display' => false              // [optional] Prevent display of the field for this locale
                    )
                )
            ),
        );
    ))
;
