### PR TITLE
Updated translations definitions to protected

### DIFF
--- a/Util/KnpTranslatable.php
+++ b/Util/KnpTranslatable.php
@@ -9,10 +9,11 @@ namespace A2lix\TranslationFormBundle\Util;
  */
 trait KnpTranslatable
 {
+
     /**
      * @Symfony\Component\Validator\Constraints\Valid(deep=true)
      */
-    private $translations;
+    protected $translations;
     private $newTranslations;
     private $currentLocale;
 


### PR DESCRIPTION
If translations field is private, and some translatable field is needed for being serialized, for example, some kind of user, an error is thrown.

This only happens when the Entity which uses this trait is abstract.

At the moment, only $translations definition affects to some cases, not sure all other fields are in similar problem
