### PR TITLE
Update composer.json to allow symfony 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "2.3.*"
+        "symfony/symfony": ">=2.3"
     },
     "suggest": {
         "a2lix/i18n-doctrine-bundle": "For A2lix strategy",


### PR DESCRIPTION
Required if you need to use the combination of Sf2.4, Stof anda2lix.
