### PR TITLE
Support translation form on non-Doctrine objects

### DIFF
--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -36,8 +36,7 @@ class TranslationForm implements TranslationFormInterface
         
         $translationClass = ClassUtils::getRealClass($translationClass);
         $manager = $this->managerRegistry->getManagerForClass($translationClass);
-        if (null === $manager)
-        {
+        if (null === $manager) {
             $metadataClass = $manager->getMetadataFactory()->getMetadataFor($translationClass);
             
             foreach ($metadataClass->fieldMappings as $fieldMapping) {


### PR DESCRIPTION
I wanted to use the translation form on an object, which is not a Doctrine entity. Unfortunately this was not possible because the form is is trying to fetch Doctrine meta data on a non-existing manager. So I made this little modification, which will make it possible to use the form on a non-Doctrine object. In that case you will have to do an explicit configuration of the translation fields.
