### PR TITLE
javascript:void(0) conflict with Jquery

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -6,7 +6,7 @@
             {% set locale = translationsFields.vars.name %}
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="javascript:void(0)" data-toggle="tab" data-target=".a2lix_translationsFields-{{ locale }}">
+                <a href="#" data-toggle="tab" data-target=".a2lix_translationsFields-{{ locale }}">
                     {{ locale|capitalize }}
                     {% if form.vars.default_locale == locale %}[Default]{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}


### PR DESCRIPTION
'javascript:void(0) conflict with Jquery' can create the following error with jquery :
Uncaught Error: Syntax error, unrecognized expression: unsupported pseudo: void
