### PR TITLE
Error on translating booleans

### DIFF
--- a/Form/DataMapper/GedmoTranslationMapper.php
+++ b/Form/DataMapper/GedmoTranslationMapper.php
@@ -31,10 +31,11 @@ class GedmoTranslationMapper implements DataMapperInterface
             $tmpFormData = array();
             foreach ($data as $translation) {
                 if ($locale === $translation->getLocale()) {
-                    if('checkbox' === $fields[$translation->getField()]['field_type'])
+                    if ('checkbox' === $fields[$translation->getField()]['field_type']) {
                         $tmpFormData[$translation->getField()] = (bool)$translation->getContent();
-                    else
+                    } else {
                         $tmpFormData[$translation->getField()] = $translation->getContent();
+                    }
                 }
             }
             $translationsFieldsForm->setData($tmpFormData);

--- a/Form/DataMapper/GedmoTranslationMapper.php
+++ b/Form/DataMapper/GedmoTranslationMapper.php
@@ -26,11 +26,15 @@ class GedmoTranslationMapper implements DataMapperInterface
 
         foreach ($forms as $translationsFieldsForm) {
             $locale = $translationsFieldsForm->getConfig()->getName();
+            $fields = $translationsFieldsForm->getConfig()->getOption('fields');
 
             $tmpFormData = array();
             foreach ($data as $translation) {
                 if ($locale === $translation->getLocale()) {
-                    $tmpFormData[$translation->getField()] = $translation->getContent();
+                    if('checkbox' === $fields[$translation->getField()]['field_type'])
+                        $tmpFormData[$translation->getField()] = (bool)$translation->getContent();
+                    else
+                        $tmpFormData[$translation->getField()] = $translation->getContent();
                 }
             }
             $translationsFieldsForm->setData($tmpFormData);


### PR DESCRIPTION
Hi,

First of all, I'm not sure if this is a bug on your part, so I apologize in advance if it isn't.

I was trying to translate a boolean field, but although the value is recorded correctly, when Symfony tries to retrieve the value, it throws me a TransformationFailedException when trying to do this:

`BooleanToStringTransformer->transform ('1')`

Boolean/checkbox fields work different in forms, so I think it is necessary to cast the value before passing it to the form.

Thanks in advance.
