### PR TITLE
Fix compatibility with NelmioApiDocBundle

### DIFF
--- a/Form/EventListener/GedmoTranslationsListener.php
+++ b/Form/EventListener/GedmoTranslationsListener.php
@@ -39,7 +39,7 @@ class GedmoTranslationsListener implements EventSubscriberInterface
     {
         $form = $event->getForm();
 
-        $translatableClass = $form->getParent()->getConfig()->getDataClass();
+        $translatableClass = $form->getParent() ? $form->getParent()->getConfig()->getDataClass() : null;
 
         $formOptions = $form->getConfig()->getOptions();
         $childrenOptions = $this->translationForm->getChildrenOptions($translatableClass, $formOptions);


### PR DESCRIPTION
The plugin is not compatible with [NelmioApiDocBundle](https://github.com/nelmio/NelmioApiDocBundle), since the `$form->getParent()` calls return `null` when there is no request context.

Therefore, I've added a small fix to not cause errors when this is done. I haven't experienced any problems because of this.
