### PR TITLE
Multiple translations on same page - bootstrap tabs

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -6,7 +6,7 @@
             {% set locale = translationsFields.vars.name %}
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="#" data-toggle="tab" data-target=".a2lix_translationsFields-{{ locale }}">
+                <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}-a2lix_translationsFields-{{ locale }}">
                     {{ locale|capitalize }}
                     {% if form.vars.default_locale == locale %}[Default]{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -19,7 +19,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div class="a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
+            <div class="{{ translationsFields.vars.id }}-a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
Updated data-target and class for tabs.

When having multiple fields on same page for collections all tabs are same class. So when switching tabs, all tabs are switched and not updated.