### PR TITLE
Fetch translation class from getTranslation(Entity)Class

### DIFF
--- a/Form/EventListener/TranslationsListener.php
+++ b/Form/EventListener/TranslationsListener.php
@@ -31,14 +31,7 @@ class TranslationsListener implements EventSubscriberInterface
     {
         $form = $event->getForm();
 
-        $translatableClass = $form->getParent()->getConfig()->getDataClass();
-        if (method_exists($translatableClass, "getTranslationEntityClass")) {
-            $translationClass = $translatableClass::getTranslationEntityClass();
-        } elseif (method_exists($translatableClass, "getTranslationClass")) {
-            $translationClass = $translatableClass::getTranslationClass();
-        } else {
-            $translationClass = $translatableClass .'Translation';
-        }
+        $translationClass = $this->getTranslationClass($form);
 
         $formOptions = $form->getConfig()->getOptions();
         $fieldsOptions = $this->translationForm->getFieldsOptions($translationClass, $formOptions);
@@ -79,5 +72,21 @@ class TranslationsListener implements EventSubscriberInterface
             FormEvents::PRE_SET_DATA => 'preSetData',
             FormEvents::SUBMIT => 'submit',
         );
+    }
+    
+    /**
+     *
+     * @param \Symfony\Component\Form\Form $form
+     */
+    private function getTranslationClass($form)
+    {
+        $translatableClass = $form->getParent()->getConfig()->getDataClass();
+        if (method_exists($translatableClass, "getTranslationEntityClass")) { // Knp
+            return $translatableClass::getTranslationEntityClass();
+        } elseif (method_exists($translatableClass, "getTranslationClass")) { // Gedmo
+            return $translatableClass::getTranslationClass();
+        } else {
+            return $translatableClass .'Translation';
+        }
     }
 }


### PR DESCRIPTION
This pull request uses the `getTranslationEntityClass` from KNP or the `getTranslationClass` from Gedmo, instead of forcing the user to name their translation classes "[ClassName]Translation". As a fallback it still assumes that the standard naming convention.

This also fixes a problem with entity inheritance. In one of my projects I have an abstract entity "Item", which makes use of translations and another entity named "Weapon", which inherits from it. Unfortunatley the TranslationFormBundle assumes the translation class being called WeaponTranslation instead of ItemTranslation and there is no way to change this behaviour :(

Would be nice if you could merge it or give me some feedback how to solve that problem.
