### PR TITLE
Locale provider as a service

### DIFF
--- a/A2lixTranslationFormBundle.php
+++ b/A2lixTranslationFormBundle.php
@@ -4,7 +4,8 @@ namespace A2lix\TranslationFormBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle,
     Symfony\Component\DependencyInjection\ContainerBuilder,
-    A2lix\TranslationFormBundle\DependencyInjection\Compiler\TemplatingPass;
+    A2lix\TranslationFormBundle\DependencyInjection\Compiler\TemplatingPass,
+    A2lix\TranslationFormBundle\DependencyInjection\Compiler\LocaleProviderPass;
 
 /**
  * @author David ALLIX
@@ -16,5 +17,6 @@ class A2lixTranslationFormBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new TemplatingPass());
+        $container->addCompilerPass(new LocaleProviderPass());
     }
 }

--- a/DependencyInjection/A2lixTranslationFormExtension.php
+++ b/DependencyInjection/A2lixTranslationFormExtension.php
@@ -8,14 +8,16 @@ use Symfony\Component\DependencyInjection\ContainerBuilder,
     Symfony\Component\HttpKernel\DependencyInjection\Extension,
     Symfony\Component\DependencyInjection\Loader;
 
+
 /**
  * @author David ALLIX
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class A2lixTranslationFormExtension extends Extension
 {
     /**
      *
-     * @param array $configs
+     * @param array                                                   $configs
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
     public function load(array $configs, ContainerBuilder $container)
@@ -23,14 +25,16 @@ class A2lixTranslationFormExtension extends Extension
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->setParameter('a2lix_translation_form.locale_provider', $config['locale_provider']);
         $container->setParameter('a2lix_translation_form.locales', $config['locales']);
         $container->setParameter('a2lix_translation_form.default_locale', $container->getParameter('kernel.default_locale', 'en'));
         $container->setParameter('a2lix_translation_form.required_locales', $config['required_locales']);
+
         $container->setParameter('a2lix_translation_form.templating', $config['templating']);
-        
+
         $container->setAlias('a2lix_translation_form.manager_registry', $config['manager_registry']);
     }
 }

--- a/DependencyInjection/Compiler/LocaleProviderPass.php
+++ b/DependencyInjection/Compiler/LocaleProviderPass.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author    Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ * @date      07/11/14
+ * @copyright Copyright (c) Reiss Clothing Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface,
+    Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class LocaleProviderPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $localeProvider = $container->getParameter('a2lix_translation_form.locale_provider');
+
+        if ('default' == $localeProvider) {
+            $container->setAlias('a2lix_translation_form.default.service.locale_provider', 'a2lix_translation_form.default.service.parameter_locale_provider');
+
+            $definition = $container->getDefinition('a2lix_translation_form.default.service.parameter_locale_provider');
+
+            $definition->setArguments(array(
+                $container->getParameter('a2lix_translation_form.locales'),
+                $container->getParameter('a2lix_translation_form.default_locale'),
+                $container->getParameter('a2lix_translation_form.required_locales')
+            ));
+        } else {
+            $container->setAlias('a2lix_translation_form.default.service.locale_provider', $localeProvider);
+        }
+    }
+} 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder,
 
 /**
  * @author David ALLIX
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class Configuration implements ConfigurationInterface
 {
@@ -20,6 +21,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->scalarNode('locale_provider')->defaultValue('default')->end()
                 ->arrayNode('locales')
                     ->beforeNormalization()
                         ->ifString()

--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -8,35 +8,30 @@ use Symfony\Component\Form\FormView,
     Symfony\Component\Form\FormBuilderInterface,
     Symfony\Component\OptionsResolver\OptionsResolverInterface,
     A2lix\TranslationFormBundle\TranslationForm\TranslationForm,
-    A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener;
+    A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener,
+    A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
 
 /**
- *
  * @author David ALLIX
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class TranslationsFormsType extends AbstractType
 {
     private $translationForm;
     private $translationsListener;
-    private $locales;
-    private $defaultLocale;
-    private $requiredLocales;
+    private $localeProvider;
 
     /**
      *
-     * @param \A2lix\TranslationFormBundle\TranslationForm\TranslationForm $translationForm
+     * @param \A2lix\TranslationFormBundle\TranslationForm\TranslationForm              $translationForm
      * @param \A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener $translationsListener
-     * @param array $locales
-     * @param string $defaultLocale
-     * @param array $requiredLocales
+     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface               $localeProvider
      */
-    public function __construct(TranslationForm $translationForm, TranslationsFormsListener $translationsListener, array $locales, $defaultLocale, array $requiredLocales = array())
+    public function __construct(TranslationForm $translationForm, TranslationsFormsListener $translationsListener,  LocaleProviderInterface $localeProvider)
     {
         $this->translationForm = $translationForm;
         $this->translationsListener = $translationsListener;
-        $this->locales = $locales;
-        $this->defaultLocale = $defaultLocale;
-        $this->requiredLocales = $requiredLocales;
+        $this->localeProvider = $localeProvider;
     }
 
     /**
@@ -66,7 +61,7 @@ class TranslationsFormsType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['default_locale'] = $this->defaultLocale;
+        $view->vars['default_locale'] = $this->localeProvider->getDefaultLocale();
         $view->vars['required_locales'] = $options['required_locales'];
     }   
 
@@ -78,8 +73,8 @@ class TranslationsFormsType extends AbstractType
     {
         $resolver->setDefaults(array(
             'by_reference' => false,
-            'locales' => $this->locales,
-            'required_locales' => $this->requiredLocales,
+            'locales' => $this->localeProvider->getLocales(),
+            'required_locales' => $this->localeProvider->getRequiredLocales(),
             'form_type' => null,
             'form_options' => array(),
         ));

--- a/Form/Type/TranslationsLocalesSelectorType.php
+++ b/Form/Type/TranslationsLocalesSelectorType.php
@@ -5,27 +5,24 @@ namespace A2lix\TranslationFormBundle\Form\Type;
 use Symfony\Component\Form\FormView,
     Symfony\Component\Form\AbstractType,
     Symfony\Component\Form\FormInterface,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    Symfony\Component\OptionsResolver\OptionsResolverInterface,
+    A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
 
 /**
- *
- *
  * @author David ALLIX
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class TranslationsLocalesSelectorType extends AbstractType
 {
-    private $locales;
-    private $defaultLocale;
+    private $localeProvider;
 
     /**
      *
-     * @param array $locales
-     * @param string $defaultLocale
+     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface $localeProvider
      */
-    public function __construct(array $locales, $defaultLocale)
+    public function __construct(LocaleProviderInterface $localeProvider)
     {
-        $this->locales = $locales;
-        $this->defaultLocale = $defaultLocale;
+        $this->localeProvider = $localeProvider;
     }
 
     /**
@@ -36,7 +33,7 @@ class TranslationsLocalesSelectorType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['default_locale'] = $this->defaultLocale;
+        $view->vars['default_locale'] = $this->localeProvider->getDefaultLocale();
     }
 
     /**
@@ -46,7 +43,7 @@ class TranslationsLocalesSelectorType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'choices' => array_combine($this->locales, $this->locales),
+            'choices' => array_combine($this->localeProvider->getLocales(), $this->localeProvider->getLocales()),
             'expanded' => true,
             'multiple' => true,
             'attr' => array(

--- a/Form/Type/TranslationsType.php
+++ b/Form/Type/TranslationsType.php
@@ -7,33 +7,29 @@ use Symfony\Component\Form\FormView,
     Symfony\Component\Form\FormInterface,
     Symfony\Component\Form\FormBuilderInterface,
     Symfony\Component\OptionsResolver\OptionsResolverInterface,
-    A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener;
+    A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener,
+    A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
 
 /**
  * Regroup by locales, all translations fields
  *
  * @author David ALLIX
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class TranslationsType extends AbstractType
 {
     private $translationsListener;
-    private $locales;
-    private $defaultLocale;
-    private $requiredLocales;
+    private $localeProvider;
 
     /**
      *
      * @param \A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener $translationsListener
-     * @param array $locales
-     * @param string $defaultLocale
-     * @param array $requiredLocales
+     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface          $localeProvider
      */
-    public function __construct(TranslationsListener $translationsListener, array $locales, $defaultLocale, array $requiredLocales = array())
+    public function __construct(TranslationsListener $translationsListener, LocaleProviderInterface $localeProvider)
     {
         $this->translationsListener = $translationsListener;
-        $this->locales = $locales;
-        $this->defaultLocale = $defaultLocale;
-        $this->requiredLocales = $requiredLocales;
+        $this->localeProvider = $localeProvider;
     }
 
     /**
@@ -67,9 +63,9 @@ class TranslationsType extends AbstractType
         $resolver->setDefaults(array(
             'by_reference' => false,
             'empty_data' => new \Doctrine\Common\Collections\ArrayCollection(),
-            'locales' => $this->locales,
-            'default_locale' => $this->defaultLocale,
-            'required_locales' => $this->requiredLocales,
+            'locales' => $this->localeProvider->getLocales(),
+            'default_locale' => $this->localeProvider->getDefaultLocale(),
+            'required_locales' => $this->localeProvider->getRequiredLocales(),
             'fields' => array(),
             'exclude_fields' => array(),
         ));

--- a/Locale/DefaultProvider.php
+++ b/Locale/DefaultProvider.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ * @date 07/11/14
+ * @copyright Copyright (c) Reiss Clothing Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Locale;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class DefaultProvider implements LocaleProviderInterface
+{
+    /**
+     * Locales
+     *
+     * @var array
+     */
+    protected $locales;
+
+    /**
+     * Default locale
+     *
+     * @var
+     */
+    protected $defaultLocale;
+
+    /**
+     * Required locales
+     *
+     * @var array
+     */
+    protected $requiredLocales;
+
+    /**
+     * @param array $locales
+     * @param       $defaultLocale
+     * @param array $requiredLocales
+     */
+    public function __construct(array $locales, $defaultLocale, array $requiredLocales = array())
+    {
+        if (!in_array($defaultLocale, $locales)) {
+            throw new \InvalidArgumentException('Default locale should be contained in locales');
+        }
+
+        $diff = array_diff($requiredLocales, $locales);
+        if (!empty($diff)) {
+            throw new \InvalidArgumentException('Required locales should be contained in locales');
+        }
+
+        $this->locales = $locales;
+        $this->defaultLocale = $defaultLocale;
+        $this->requiredLocales = $requiredLocales;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public function getLocales()
+    {
+        return $this->locales;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public function getDefaultLocale()
+    {
+        return $this->defaultLocale;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public function getRequiredLocales()
+    {
+        return $this->requiredLocales;
+    }
+} 

--- a/Locale/LocaleProviderInterface.php
+++ b/Locale/LocaleProviderInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ * @date 07/11/14
+ * @copyright Copyright (c) Reiss Clothing Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Locale;
+
+/**
+ * Provides the locales
+ *
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+interface LocaleProviderInterface
+{
+    /**
+     * Get array of locales
+     *
+     * @return array
+     */
+    public function getLocales();
+
+    /**
+     * Get default locale
+     *
+     * @return string
+     */
+    public function getDefaultLocale();
+
+    /**
+     * Get required locales
+     *
+     * @return array
+     */
+    public function getRequiredLocales();
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,7 +9,8 @@
         <parameter key="a2lix_translation_form.required_locales" />
 
         <parameter key="a2lix_translation_form.default.service.translation.class">A2lix\TranslationFormBundle\TranslationForm\TranslationForm</parameter>
-        
+        <parameter key="a2lix_translation_form.default.service.parameter_locale_provider.class">A2lix\TranslationFormBundle\Locale\DefaultProvider</parameter>
+
         <parameter key="a2lix_translation_form.default.listener.translations.class">A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener</parameter>
         <parameter key="a2lix_translation_form.default.listener.translationsForms.class">A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener</parameter>
         
@@ -26,7 +27,9 @@
             <argument type="service" id="form.registry" />
             <argument type="service" id="a2lix_translation_form.manager_registry" />
         </service>
-        
+        <service id="a2lix_translation_form.default.service.parameter_locale_provider" class="%a2lix_translation_form.default.service.parameter_locale_provider.class%">
+        </service>
+
         <!-- Listeners -->
         <service id="a2lix_translation_form.default.listener.translations" class="%a2lix_translation_form.default.listener.translations.class%">
             <argument type="service" id="a2lix_translation_form.default.service.translation" />
@@ -37,9 +40,7 @@
         <!-- Form Types -->
         <service id="a2lix_translation_form.default.type.translations" class="%a2lix_translation_form.default.type.translations.class%">
             <argument type="service" id="a2lix_translation_form.default.listener.translations" />
-            <argument>%a2lix_translation_form.locales%</argument>
-            <argument>%a2lix_translation_form.default_locale%</argument>
-            <argument>%a2lix_translation_form.required_locales%</argument>
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
             <tag name="form.type" alias="a2lix_translations" />
         </service>
         <service id="a2lix_translation_form.default.type.translationsFields" class="%a2lix_translation_form.default.type.translationsFields.class%">
@@ -48,14 +49,11 @@
         <service id="a2lix_translation_form.default.type.translationsForms" class="%a2lix_translation_form.default.type.translationsForms.class%">
             <argument type="service" id="a2lix_translation_form.default.service.translation" />
             <argument type="service" id="a2lix_translation_form.default.listener.translationsForms" />
-            <argument>%a2lix_translation_form.locales%</argument>
-            <argument>%a2lix_translation_form.default_locale%</argument>
-            <argument>%a2lix_translation_form.required_locales%</argument>
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
             <tag name="form.type" alias="a2lix_translationsForms" />
         </service>
         <service id="a2lix_translation_form.default.type.translationsLocalesSelector" class="%a2lix_translation_form.default.type.translationsLocalesSelector.class%">
-            <argument>%a2lix_translation_form.locales%</argument>
-            <argument>%a2lix_translation_form.default_locale%</argument>
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
             <tag name="form.type" alias="a2lix_translationsLocalesSelector" />
         </service>
         <service id="a2lix_translation_form.default.type.translatedEntity" class="%a2lix_translation_form.default.type.translatedEntity.class%">

--- a/Tests/Locale/DefaultProviderTest.php
+++ b/Tests/Locale/DefaultProviderTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ * @date 07/11/14
+ * @copyright Copyright (c) Reiss Clothing Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Tests\Locale;
+
+use A2lix\TranslationFormBundle\Locale\DefaultProvider;
+
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class DefaultProviderTest extends \PHPUnit_Framework_TestCase
+{
+    protected $provider;
+    protected $locales;
+    protected $defaultLocale;
+    protected $requiredLocales;
+
+    public function setUp()
+    {
+        $this->locales = array('es', 'en', 'pt');
+        $this->defaultLocale = 'en';
+        $this->requiredLocales = array('es', 'en');
+
+        $this->provider = new DefaultProvider($this->locales, $this->defaultLocale, $this->requiredLocales);
+    }
+
+    public function testDefaultLocaleIsInLocales()
+    {
+        $classname = 'A2lix\TranslationFormBundle\Locale\DefaultProvider';
+
+        // Get mock, without the constructor being called
+        $mock = $this->getMockBuilder($classname)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // set expectations for constructor calls
+        $this->setExpectedException(
+            'InvalidArgumentException', 'Default locale should be contained in locales'
+        );
+
+        // now call the constructor
+        $reflectedClass = new \ReflectionClass($classname);
+        $constructor = $reflectedClass->getConstructor();
+        $constructor->invoke($mock, array('es', 'en'), 'de', array());
+    }
+
+    public function testRequiredLocaleAreInLocales()
+    {
+        $classname = 'A2lix\TranslationFormBundle\Locale\DefaultProvider';
+
+        // Get mock, without the constructor being called
+        $mock = $this->getMockBuilder($classname)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // set expectations for constructor calls
+        $this->setExpectedException(
+            'InvalidArgumentException', 'Required locales should be contained in locales'
+        );
+
+        // now call the constructor
+        $reflectedClass = new \ReflectionClass($classname);
+        $constructor = $reflectedClass->getConstructor();
+        $constructor->invoke($mock, array('es', 'en'), 'en', array('en', 'pt'));
+    }
+
+    public function testGetLocales()
+    {
+        $expected = $this->provider->getLocales();
+        $locales = $this->locales;
+
+        $this->assertSame(array_diff($expected, $locales), array_diff($locales, $expected));
+    }
+
+    public function testGetDefaultLocale()
+    {
+        $expected = $this->provider->getDefaultLocale();
+
+        $this->assertEquals($this->defaultLocale, $expected);
+    }
+
+    public function getRequiredLocales()
+    {
+        $expected = $this->provider->getDefaultLocale();
+        $requiredLocales = $this->requiredLocales;
+
+        $this->assertSame(array_diff($expected, $requiredLocales), array_diff($requiredLocales, $expected));
+    }
+} 


### PR DESCRIPTION
Locales are provided by a service.
The default service gets the locales from configuration, but it can be overriden by any service that implements `LocaleProviderInterface` to retrieve them from DB for example.
