### PR TITLE
Add empty_data to a2lix_translationsForms form type (ArrayCollection)

### DIFF
--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -73,6 +73,7 @@ class TranslationsFormsType extends AbstractType
     {
         $resolver->setDefaults(array(
             'by_reference' => false,
+            'empty_data' => new \Doctrine\Common\Collections\ArrayCollection(),
             'locales' => $this->localeProvider->getLocales(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),
             'form_type' => null,


### PR DESCRIPTION
Add fix for the form type `a2lix_translationsForms`, which had no `empty_data` set. See issue #95.
