### PR TITLE
Use a closure for types empty_data

### DIFF
--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -73,7 +73,9 @@ class TranslationsFormsType extends AbstractType
     {
         $resolver->setDefaults(array(
             'by_reference' => false,
-            'empty_data' => new \Doctrine\Common\Collections\ArrayCollection(),
+            'empty_data' => function (FormInterface $form) {
+                return new \Doctrine\Common\Collections\ArrayCollection();
+            },
             'locales' => $this->localeProvider->getLocales(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),
             'form_type' => null,

--- a/Form/Type/TranslationsType.php
+++ b/Form/Type/TranslationsType.php
@@ -62,7 +62,9 @@ class TranslationsType extends AbstractType
     {
         $resolver->setDefaults(array(
             'by_reference' => false,
-            'empty_data' => new \Doctrine\Common\Collections\ArrayCollection(),
+            'empty_data' => function (FormInterface $form) {
+                return new \Doctrine\Common\Collections\ArrayCollection();
+            },
             'locales' => $this->localeProvider->getLocales(),
             'default_locale' => $this->localeProvider->getDefaultLocale(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),


### PR DESCRIPTION
 to allow several translation fields on the same form. See #183 