### PR TITLE
Remove deprecated calls as per Symfony 2.6

### DIFF
--- a/Form/Type/TranslatedEntityType.php
+++ b/Form/Type/TranslatedEntityType.php
@@ -3,7 +3,7 @@
 namespace A2lix\TranslationFormBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface,
+    Symfony\Component\OptionsResolver\OptionsResolver,
     Symfony\Component\OptionsResolver\Options,
     Symfony\Component\HttpFoundation\Request,
     Doctrine\ORM\EntityRepository;
@@ -24,9 +24,9 @@ class TranslatedEntityType extends AbstractType
 
     /**
      * 
-     * @param \Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'translation_path' => 'translations',

--- a/Form/Type/TranslationsFieldsType.php
+++ b/Form/Type/TranslationsFieldsType.php
@@ -4,7 +4,7 @@ namespace A2lix\TranslationFormBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType,
     Symfony\Component\Form\FormBuilderInterface,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface;
+    Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Translations fields
@@ -30,9 +30,9 @@ class TranslationsFieldsType extends AbstractType
 
     /**
      *
-     * @param \Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'fields' => array(),

--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\FormView,
     Symfony\Component\Form\AbstractType,
     Symfony\Component\Form\FormInterface,
     Symfony\Component\Form\FormBuilderInterface,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface,
+    Symfony\Component\OptionsResolver\OptionsResolver,
     A2lix\TranslationFormBundle\TranslationForm\TranslationForm,
     A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener,
     A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
@@ -67,9 +67,9 @@ class TranslationsFormsType extends AbstractType
 
     /**
      * 
-     * @param \Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'by_reference' => false,

--- a/Form/Type/TranslationsLocalesSelectorType.php
+++ b/Form/Type/TranslationsLocalesSelectorType.php
@@ -5,7 +5,7 @@ namespace A2lix\TranslationFormBundle\Form\Type;
 use Symfony\Component\Form\FormView,
     Symfony\Component\Form\AbstractType,
     Symfony\Component\Form\FormInterface,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface,
+    Symfony\Component\OptionsResolver\OptionsResolver,
     A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
 
 /**
@@ -38,9 +38,9 @@ class TranslationsLocalesSelectorType extends AbstractType
 
     /**
      *
-     * @param \Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'choices' => array_combine($this->localeProvider->getLocales(), $this->localeProvider->getLocales()),

--- a/Form/Type/TranslationsType.php
+++ b/Form/Type/TranslationsType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\FormView,
     Symfony\Component\Form\AbstractType,
     Symfony\Component\Form\FormInterface,
     Symfony\Component\Form\FormBuilderInterface,
-    Symfony\Component\OptionsResolver\OptionsResolverInterface,
+    Symfony\Component\OptionsResolver\OptionsResolver,
     A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener,
     A2lix\TranslationFormBundle\Locale\LocaleProviderInterface;
 
@@ -56,9 +56,9 @@ class TranslationsType extends AbstractType
 
     /**
      *
-     * @param \Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'by_reference' => false,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.3"
+        "symfony/symfony": ">=2.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1",


### PR DESCRIPTION
Calls to `setDefaultOptions` are deprecated and should be changed to `configureOptions` from Symfony 2.6 on. This PR fixes that for this Bundle