### PR TITLE
fix for translabie fields in sonata_type_collection form types

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -4,9 +4,10 @@
         <ul class="a2lix_translationsLocales nav nav-tabs">
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
+            {% set suffix = locale~'-'~form.vars.id %}
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="#" data-toggle="tab" data-target=".a2lix_translationsFields-{{ locale }}">
+                <a href="#" data-toggle="tab" data-target=".a2lix_translationsFields-{{ suffix }}">
                     {{ locale|capitalize }}
                     {% if form.vars.default_locale == locale %}[Default]{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -18,8 +19,8 @@
         <div class="a2lix_translationsFields tab-content">
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
-
-            <div class="a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
+            {% set suffix = locale~'-'~form.vars.id %}
+            <div class="a2lix_translationsFields-{{ suffix }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
When you add to sonata admin field of type sonata_type_collection and both the child form and base form have translations then changing translations on either of them will change visible fields (but not active tabs) on both forms.
On attached screenshot if I click En above "Name *" then en language will be shown both for names and values but the values selected tab will still be Fr (althought english field will be shown).
After this fix only fields from the same form will change.

If im not wrong same problem would occur when you have two totally separate forms with translations shown on one page.
![zaznaczenie_479](https://cloud.githubusercontent.com/assets/1465880/11116902/e8de836e-8935-11e5-83fa-b3908ab2581b.png)
