### PR TITLE
New variables to macro.html.twig

### DIFF
--- a/Resources/views/macros.html.twig
+++ b/Resources/views/macros.html.twig
@@ -1,38 +1,34 @@
 {#
 Example:
-
 {% import "A2lixTranslationFormBundle::macros.html.twig" as a2lixTranslations %}
-
-{{ a2lixTranslations.partialTranslations(editForm.translations, ['title','description']) }}
-{{ a2lixTranslations.partialTranslations(editForm.translations, ['url']) }}
+{{ a2lixTranslations.partialTranslations(editForm.translations, ['title','description'], 'my_block') }}
+{{ a2lixTranslations.partialTranslations(editForm.translations, ['url'], 'my_other_html_block') }}
 #}
-
-{% macro partialTranslations(form, fieldsNames) %}
+{% macro partial(form, fieldsNames, block) %}
     <div class="a2lix_translations tabbable">
         <ul class="a2lix_translationsLocales nav nav-tabs">
-        {% for translationsFields in form %}
-            {% set locale = translationsFields.vars.name %}
-
-            <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
-                    {{ locale|capitalize }}
-                    {% if form.vars.default_locale == locale %}[Default]{% endif %}
-                    {% if translationsFields.vars.required %}*{% endif %}
-                </a>
-            </li>
-        {% endfor %}
+            {% for translationsFields in form %}
+                {% set locale = translationsFields.vars.name %}
+                <li {% if app.request.locale == locale %}class="active"{% endif %}>
+                    <a href="#" data-toggle="tab" data-target="#{{ block ~ '-' ~ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
+                        {{ locale|capitalize }}
+                        {% if form.vars.default_locale == locale %}{% endif %}
+                        {% if translationsFields.vars.required %}*{% endif %}
+                    </a>
+                </li>
+            {% endfor %}
         </ul>
 
         <div class="a2lix_translationsFields tab-content">
-        {% for translationsFields in form %}
-            {% set locale = translationsFields.vars.name %}
-
-            <div class="{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }} a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
-            {% for translationsField in translationsFields if translationsField.vars.name in fieldsNames %}
-                {{ form_row(translationsField) }}
+            {% for translationsFields in form %}
+                {% set locale = translationsFields.vars.name %}
+                <div id= "{{ block ~ '-' ~ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}" class="a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
+                    {% for translationsField in translationsFields if translationsField.vars.name in fieldsNames %}
+                        {{ form_row(translationsField) }}
+                    {% endfor %}
+                </div>
             {% endfor %}
-            </div>
-        {% endfor %}
         </div>
     </div>
 {% endmacro %}
+


### PR DESCRIPTION
When I started using macros.html.twig, I realized that the click in one tab was changing the content of the other tabs on the page. However the other tabs weren't changing. As a consequence, I thought I was filling the field in one language when I was actually filling it in another language. I suggest to add a new variable to macros template called blocks. With this variable, it is possible to link the right tab with the right html block. 