### PR TITLE
Fix error in Symfony 3.0, deprecated pattern option in 2.5

### DIFF
--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -145,17 +145,19 @@ class TranslationForm implements TranslationFormInterface
             $options['field_type'] = $typeGuess->getType();
         }
 
-        if (!isset($options['pattern']) && ($patternGuess = $guesser->guessPattern($class, $property))) {
-            $options['pattern'] = $patternGuess->getValue();
-        }
-
         if (Kernel::VERSION_ID > '20512') {
             if (!isset($options['attr']['maxlength']) && ($maxLengthGuess = $guesser->guessMaxLength($class, $property))) {
                 $options['attr']['maxlength'] = $maxLengthGuess->getValue();
             }
+            if (!isset($options['attr']['pattern']) && ($patternGuess = $guesser->guessPattern($class, $property))) {
+                $options['attr']['pattern'] = $patternGuess->getValue();
+            }
         } else {
             if (!isset($options['max_length']) && ($maxLengthGuess = $guesser->guessMaxLength($class, $property))) {
                 $options['max_length'] = $maxLengthGuess->getValue();
+            }
+            if (!isset($options['pattern']) && ($patternGuess = $guesser->guessPattern($class, $property))) {
+                $options['pattern'] = $patternGuess->getValue();
             }
         }
 


### PR DESCRIPTION
Pattern option is also moved to attr (like maxlength), so it should be fixed in this way.