### PR TITLE
Allow translation labels to be translated

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -7,7 +7,7 @@
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
                 <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
-                    {{ locale|capitalize }}
+                    {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}[Default]{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
                 </a>


### PR DESCRIPTION
It seems ironic that in a multi-lingual context, the labels can't be translated.

Locales should not be left not translated.

This PR also include the support for the label attribute (could be defined by explicitly using `TranslationsFieldsType` or via a Form Extension.