### PR TITLE
Allow "default translation" ([Default]) label to be translated

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -8,7 +8,7 @@
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
                 <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
-                    {% if form.vars.default_locale == locale %}[Default]{% endif %}
+                    {% if form.vars.default_locale == locale %}{{ form.vars.default_label|default('[Default]')|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
                 </a>
             </li>


### PR DESCRIPTION
This is a follow up on #231, the point is pretty much the same too... We should allow for the "[Default]" label to be translated too.

This PR also include the support for the `default_label` var (in the FormView) to override the translation key (it's very easy to do via a Form Extension on `TranslationsType`, for example, I can provide an example if you wish).