### PR TITLE
Allow easier form themeing of translated fields through _form_translations_entry_...

### DIFF
--- a/Form/EventListener/TranslationsListener.php
+++ b/Form/EventListener/TranslationsListener.php
@@ -47,7 +47,8 @@ class TranslationsListener implements EventSubscriberInterface
                         array(
                             'data_class' => $translationClass,
                             'fields' => $fieldsOptions[$locale],
-                            'required' => in_array($locale, $formOptions['required_locales'])
+                            'required' => in_array($locale, $formOptions['required_locales']),
+                            'block_name' => 'entry',
                         )
                     );
                 }


### PR DESCRIPTION
Hello,

This PR allows for easier [form themeing][form themeing] of translated fields.

**:warning: This PR might be considered a backward compatibility break in some cases, see at the bottom of the post for a discussion on this issue. :warning:**

#### Now
Currently, to modify the rendering of translated fields, we have three choices:

###### 1. Change the themeing of ALL `translations_fields` (through `{% block a2lix_translationsFelds_{label|widget|row} %}` 

This is impractical if we have several `TranslationsFormType` in our form because (for example), we need to render several independent translation block (because, e.g., they are used on different tabs).

This does not allow form themeing the fields inside the translation but only the `translations_fields` container itself.

###### 2. Store generic customizations (such as `{% block text_widget %}`) for each translations fields in separate files (and use `{% form_theme form.translation1 "file1.html.twig" %} ...`)

This forces us to creates a number of ancillary files which don't really have any reason to exist. making the templating code harder to read and maintain. Moreover, it stills has some limits if we need to precisely target a particular field within the `translations_fields`.

###### 3. Copy/Paste the change for EACH locale of a given `translations_fields` (through `{% block _form_FIELD_LOCALE_FIELD_{label|widget|row} %}` )

This is impractical because we need to edit all our templates if we want to add a locale. Moreover, if we want to customize an additional fields, we have to remember to copy/paste the customization for each locale. It creates extremely huge templates very quickly.

###### 4. Store generic customizations (such as `{% block text_widget %}`) for each fields in separate files (and use `{% form_theme form.translation1.LOCALE.FIELD "file1.html.twig" %} ...`)

This leads to both the problems of (2.) and (3.): a lot of small files hard to maintain and a lot of copy-pasta for each locale and field.

#### This PR
This modification allows us to acheive the customization granularity of (3.) and (4.) while preventing the code duplication issue by using the same trick used to [form theme collections][collections form themeing].

With this PR, we can simply use `{% block _form_FIELD_entry_FIELD_{label|widget|row} %}` to customize each translation field for all the locales.

If a particular locale needs to be further independently customized, then we can still use something similar to (2.). However, in this case, the customization will probably be tied to some of the locale peculiarities (for example, ltr vs rtl direction, unusual text length requiring the application of additional styling and rendering, ...). These uses cases tend to be re-used across the templates so the form themeing would have already been put in its own file.

#### Backward compatibility
Symfony does not allow a field to declare multiple additional block_prefixes, so providing the new *_entry_* block prefix prevents the current *_LOCALE_* to be used. Hence, previous form themeing using `{% block _form_FIELD_LOCALE_FIELD_{label|widget|row} %}` will stop working.

It could be possible to provide a backward compatible way to do this, via a FormExtension. The solution would be to rely on a semantic configuration (e.g., "uniform_form_themeing") with two possible values (`true` or `false`). The default value (`false`), would disable the feature introduced by this PR and be deprecated. The `true` value would enable the feature introduced by this PR. This would preserve BC completely. **Tell me if you prefer this option and I'll implement it.**

[form themeing]: http://symfony.com/doc/current/cookbook/form/form_customization.html#form-theming
[collections form themeing]: http://symfony.com/doc/current/cookbook/form/form_customization.html#how-to-customize-a-collection-prototype