### PR TITLE
Introduced option to target all translations

### DIFF
--- a/Resources/public/js/a2lix_translation_default.js
+++ b/Resources/public/js/a2lix_translation_default.js
@@ -3,6 +3,18 @@ $(function() {
         evt.preventDefault();
 
         var target = $(this).attr('data-target');
+
+        if (target === 'all') {
+            $(this).parent().siblings().find('a').each(function (i, el) {
+                var targetData = $(el).data('target');
+
+                $('li:has(a[data-target="' + targetData + '"])').removeClass('active');
+                $('li:has(a[data-target="all"]), div' + targetData, 'div.a2lix_translations').addClass('active');
+            });
+
+            return;
+        }
+
         $('li:has(a[data-target="' + target + '"]), div' + target, 'div.a2lix_translations').addClass('active')
             .siblings().removeClass('active');
     });


### PR DESCRIPTION
This allows to have a tab for displaying all translations at the same time like this:

`
<li><a href="#" data-toggle="tab" data-target="all">All</a> </li>
`

I didn't add the tab to the template because not everyone might want it. I could add it as an option to the FormType though?