### PR TITLE
Multiple partials language change

### DIFF
--- a/Resources/views/macros.html.twig
+++ b/Resources/views/macros.html.twig
@@ -14,7 +14,7 @@ Example:
             {% set locale = translationsFields.vars.name %}
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
+                <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_{{ fieldsNames|first }}_a2lix_translationsFields-{{ locale }}">
                     {{ locale|capitalize }}
                     {% if form.vars.default_locale == locale %}[Default]{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -27,7 +27,7 @@ Example:
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div class="{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }} a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
+            <div class="{{ translationsFields.vars.id }}_{{ fieldsNames|first }}_a2lix_translationsFields-{{ locale }} a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %}">
             {% for translationsField in translationsFields if translationsField.vars.name in fieldsNames %}
                 {{ form_row(translationsField) }}
             {% endfor %}


### PR DESCRIPTION
Currently if you use this macro to create multiple partials, changing language for one partials block will change it for all ( and won't change activated tab in all blocks ) because class for tab toggle is same for every block. This is one quick solution to just grab first field name or only field name if it is just one and add it to class so we can distinguish multiple block tabs. 