### PR TITLE
Do not replace all type guess options of form fields

### DIFF
--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -142,6 +142,7 @@ class TranslationForm implements TranslationFormInterface
     public function guessMissingFieldOptions($guesser, $class, $property, $options)
     {
         if (!isset($options['field_type']) && ($typeGuess = $guesser->guessType($class, $property))) {
+            $options += $typeGuess->getOptions();
             $options['field_type'] = $typeGuess->getType();
         }
 


### PR DESCRIPTION
Not sure if it was on purpose but in our project we have some form type guessers guessing even the options and they were ignored.

BTW I cannot use master branch because I do not pass Translatable entities to the form but translatable DTOs (trying to avoid anemic domain model) instead and AutoFormBundle cannot handle it.