### PR TITLE
Added id's to translation panes to fix validation with sonata Admin.js

### DIFF
--- a/Resources/views/default.html.twig
+++ b/Resources/views/default.html.twig
@@ -6,7 +6,7 @@
             {% set locale = translationsFields.vars.name %}
 
             <li {% if app.request.locale == locale %}class="active"{% endif %}>
-                <a href="#" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
+                <a href="#translations-pane-{{ locale }}" data-toggle="tab" data-target=".{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }}">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ form.vars.default_label|default('[Default]')|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -19,7 +19,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div class="{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}">
+            <div id="translations-pane-{{ locale }}" class="{{ translationsFields.vars.id }}_a2lix_translationsFields-{{ locale }} tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
When submitting Sonata Admin forms with required fields or fields with validation logic, the browser doesn't switch to the tab containing the invalid field and won't display a validation error, so the user isn't notified of the error.
An error appears in the console:

`An invalid form control with name='s59e6433d381df[translations][nl][name]' is not focusable.`

The show_form_first_tab_with_errors function from the Sonata Admin bundle's Admin.js should handle the tab switching logic, but does not function correctly. The function expects an id for each tab to be able to access them by id. The current logic does not provide this, so to fix this I added an id containing the locale of the tab with a prefix.

