### PR TITLE
Add license and Issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+    Before you open an issue, make sure this one does not already exist.
+    Please also read the "guidelines for contributing" link above before posting.
+-->
+
+<!--
+    If you are reporting a bug, please try to fill in the following.
+    Otherwise remove it.
+-->
+
+### Environment
+
+#### Symfony packages
+
+```
+$ composer show --latest 'symfony/*'
+# Put the result here.
+```
+
+#### PHP version
+
+```
+$ php -v
+# Put the result here.
+```
+
+## Subject
+
+<!--
+    Give here as many details as possible.
+    Next sections are for ERRORS only.
+-->
+
+## Steps to reproduce
+
+## Expected results
+
+## Actual results
+
+<!--
+    If it's an error message or piece of code, use code block tags,
+    and make sure you provide the whole stack trace(s),
+    not just the first error message you can see.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
+
+<!--
+    Show us you choose the right branch.
+    Different branches are used for different things :
+    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
+    - master is for deprecation removals and other changes that cannot be done without a BC-break
+-->
+I am targeting this branch, because {reason}.
+
+<!--
+    Specify which issues will be fixed/closed.
+    Remove it if this is not related.
+-->
+
+Closes #{put_issue_number_here}
+
+## Changelog
+
+<!-- MANDATORY
+    Fill the changelog part inside the code block.
+    Follow this schema: http://keepachangelog.com/
+-->
+
+<!-- REMOVE EMPTY SECTIONS -->
+```markdown
+### Added
+- Added some `Class::newMethod` to do great stuff
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+```
+
+## To do
+
+<!--
+    If this is a work in progress, COMPLETE and ADD needed tasks.
+    You can add as many tasks as you want.
+    If some are not relevant, just REMOVE them.
+-->
+
+- [ ] Update the tests
+- [ ] Update the documentation
+- [ ] Add an upgrade note
+
+## Subject
+
+<!-- Describe your Pull Request content here -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2018 David ALLIX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Adding some PR and issue templates from Sonata directly (with minor adjustements). They work great on sonata bundles and it provides some basic stuff to be able to help people with their issues / PR.

Added license file too.