### PR TITLE
Use short array, and minor fixed on code styling

### DIFF
--- a/.flintci.yml
+++ b/.flintci.yml
@@ -1,3 +1,4 @@
 services:
   composernormalize: true
   phpcsfixer: true
+  xmllint: true

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,7 +13,7 @@ $rules = [
     '@Symfony' => true,
     '@Symfony:risky' => true,
     'array_syntax' => [
-        'syntax' => 'long',
+        'syntax' => 'short',
     ],
     'combine_consecutive_issets' => true,
     'combine_consecutive_unsets' => true,

--- a/DependencyInjection/A2lixTranslationFormExtension.php
+++ b/DependencyInjection/A2lixTranslationFormExtension.php
@@ -39,7 +39,7 @@ class A2lixTranslationFormExtension extends Extension
         $container->setParameter('a2lix_translation_form.locales', $config['locales']);
         $container->setParameter('a2lix_translation_form.required_locales', $config['required_locales']);
         $container->setParameter('a2lix_translation_form.default_locale', $config['default_locale'] ?:
-            $container->getParameter('kernel.default_locale', 'en'));
+            $container->getParameter('kernel.default_locale'));
 
         $container->setParameter('a2lix_translation_form.templating', $config['templating']);
 

--- a/DependencyInjection/Compiler/LocaleProviderPass.php
+++ b/DependencyInjection/Compiler/LocaleProviderPass.php
@@ -31,11 +31,11 @@ class LocaleProviderPass implements CompilerPassInterface
 
             $definition = $container->getDefinition('a2lix_translation_form.default.service.parameter_locale_provider');
 
-            $definition->setArguments(array(
+            $definition->setArguments([
                 $container->getParameter('a2lix_translation_form.locales'),
                 $container->getParameter('a2lix_translation_form.default_locale'),
                 $container->getParameter('a2lix_translation_form.required_locales'),
-            ));
+            ]);
         } else {
             $container->setAlias('a2lix_translation_form.default.service.locale_provider', $localeProvider);
         }

--- a/Form/EventListener/TranslationsFormsListener.php
+++ b/Form/EventListener/TranslationsFormsListener.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormEvents;
 class TranslationsFormsListener implements EventSubscriberInterface
 {
     /**
-     * @param \Symfony\Component\Form\FormEvent $event
+     * @param FormEvent $event
      */
     public function submit(FormEvent $event)
     {
@@ -39,8 +39,8 @@ class TranslationsFormsListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             FormEvents::SUBMIT => 'submit',
-        );
+        ];
     }
 }

--- a/Form/EventListener/TranslationsListener.php
+++ b/Form/EventListener/TranslationsListener.php
@@ -25,7 +25,7 @@ class TranslationsListener implements EventSubscriberInterface
     private $translationForm;
 
     /**
-     * @param \A2lix\TranslationFormBundle\TranslationForm\TranslationForm $translationForm
+     * @param TranslationForm $translationForm
      */
     public function __construct(TranslationForm $translationForm)
     {
@@ -33,7 +33,7 @@ class TranslationsListener implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\Form\FormEvent $event
+     * @param FormEvent $event
      */
     public function preSetData(FormEvent $event)
     {
@@ -51,11 +51,11 @@ class TranslationsListener implements EventSubscriberInterface
                     $form->add(
                         $locale,
                         LegacyFormHelper::getType('A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType'),
-                        array(
+                        [
                             'data_class' => $translationClass,
                             'fields' => $fieldsOptions[$locale],
                             'required' => in_array($locale, $formOptions['required_locales']),
-                        )
+                        ]
                     );
                 }
             }
@@ -63,7 +63,7 @@ class TranslationsListener implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\Form\FormEvent $event
+     * @param FormEvent $event
      */
     public function submit(FormEvent $event)
     {
@@ -81,10 +81,10 @@ class TranslationsListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             FormEvents::PRE_SET_DATA => 'preSetData',
             FormEvents::SUBMIT => 'submit',
-        );
+        ];
     }
 
     /**

--- a/Form/Type/TranslatedEntityType.php
+++ b/Form/Type/TranslatedEntityType.php
@@ -37,7 +37,7 @@ class TranslatedEntityType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'translation_path' => 'translations',
             'translation_property' => null,
             'query_builder' => function (EntityRepository $er) {
@@ -52,7 +52,7 @@ class TranslatedEntityType extends AbstractType
 
                 return $options['translation_path'].'['.$this->request->getLocale().'].'.$options['translation_property'];
             },
-        ));
+        ]);
     }
 
     // BC for SF < 2.7

--- a/Form/Type/TranslationsFieldsType.php
+++ b/Form/Type/TranslationsFieldsType.php
@@ -24,8 +24,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 class TranslationsFieldsType extends AbstractType
 {
     /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array                                        $options
+     * @param FormBuilderInterface $builder
+     * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -42,9 +42,9 @@ class TranslationsFieldsType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'fields' => array(),
-        ));
+        $resolver->setDefaults([
+            'fields' => [],
+        ]);
     }
 
     // BC for SF < 2.7

--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -32,20 +32,23 @@ class TranslationsFormsType extends AbstractType
     private $localeProvider;
 
     /**
-     * @param \A2lix\TranslationFormBundle\TranslationForm\TranslationForm              $translationForm
-     * @param \A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener $translationsListener
-     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface               $localeProvider
+     * @param TranslationForm           $translationForm
+     * @param TranslationsFormsListener $translationsListener
+     * @param LocaleProviderInterface   $localeProvider
      */
-    public function __construct(TranslationForm $translationForm, TranslationsFormsListener $translationsListener, LocaleProviderInterface $localeProvider)
-    {
+    public function __construct(
+        TranslationForm $translationForm,
+        TranslationsFormsListener $translationsListener,
+        LocaleProviderInterface $localeProvider
+    ) {
         $this->translationForm = $translationForm;
         $this->translationsListener = $translationsListener;
         $this->localeProvider = $localeProvider;
     }
 
     /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array                                        $options
+     * @param FormBuilderInterface $builder
+     * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -56,16 +59,16 @@ class TranslationsFormsType extends AbstractType
         foreach ($options['locales'] as $locale) {
             if (isset($formsOptions[$locale])) {
                 $builder->add($locale, $options['form_type'],
-                    $formsOptions[$locale] + array('required' => in_array($locale, $options['required_locales']))
+                    $formsOptions[$locale] + ['required' => in_array($locale, $options['required_locales'])]
                 );
             }
         }
     }
 
     /**
-     * @param \Symfony\Component\Form\FormView      $view
-     * @param \Symfony\Component\Form\FormInterface $form
-     * @param array                                 $options
+     * @param FormView      $view
+     * @param FormInterface $form
+     * @param array         $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
@@ -78,7 +81,7 @@ class TranslationsFormsType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'by_reference' => false,
             'empty_data' => function (FormInterface $form) {
                 return new \Doctrine\Common\Collections\ArrayCollection();
@@ -86,8 +89,8 @@ class TranslationsFormsType extends AbstractType
             'locales' => $this->localeProvider->getLocales(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),
             'form_type' => null,
-            'form_options' => array(),
-        ));
+            'form_options' => [],
+        ]);
     }
 
     // BC for SF < 2.7

--- a/Form/Type/TranslationsLocalesSelectorType.php
+++ b/Form/Type/TranslationsLocalesSelectorType.php
@@ -27,7 +27,7 @@ class TranslationsLocalesSelectorType extends AbstractType
     private $localeProvider;
 
     /**
-     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface $localeProvider
+     * @param LocaleProviderInterface $localeProvider
      */
     public function __construct(LocaleProviderInterface $localeProvider)
     {
@@ -35,9 +35,9 @@ class TranslationsLocalesSelectorType extends AbstractType
     }
 
     /**
-     * @param \Symfony\Component\Form\FormView      $view
-     * @param \Symfony\Component\Form\FormInterface $form
-     * @param array                                 $options
+     * @param FormView      $view
+     * @param FormInterface $form
+     * @param array         $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
@@ -49,14 +49,14 @@ class TranslationsLocalesSelectorType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'choices' => array_combine($this->localeProvider->getLocales(), $this->localeProvider->getLocales()),
             'expanded' => true,
             'multiple' => true,
-            'attr' => array(
+            'attr' => [
                 'class' => 'a2lix_translationsLocalesSelector',
-            ),
-        ));
+            ],
+        ]);
     }
 
     // BC for SF < 2.7

--- a/Form/Type/TranslationsType.php
+++ b/Form/Type/TranslationsType.php
@@ -32,8 +32,8 @@ class TranslationsType extends AbstractType
     private $localeProvider;
 
     /**
-     * @param \A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener $translationsListener
-     * @param \A2lix\TranslationFormBundle\Locale\LocaleProviderInterface          $localeProvider
+     * @param TranslationsListener    $translationsListener
+     * @param LocaleProviderInterface $localeProvider
      */
     public function __construct(TranslationsListener $translationsListener, LocaleProviderInterface $localeProvider)
     {
@@ -42,8 +42,8 @@ class TranslationsType extends AbstractType
     }
 
     /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     * @param array                                        $options
+     * @param FormBuilderInterface $builder
+     * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -51,9 +51,9 @@ class TranslationsType extends AbstractType
     }
 
     /**
-     * @param \Symfony\Component\Form\FormView      $view
-     * @param \Symfony\Component\Form\FormInterface $form
-     * @param array                                 $options
+     * @param FormView      $view
+     * @param FormInterface $form
+     * @param array         $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
@@ -66,7 +66,7 @@ class TranslationsType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'by_reference' => false,
             'empty_data' => function (FormInterface $form) {
                 return new \Doctrine\Common\Collections\ArrayCollection();
@@ -74,9 +74,9 @@ class TranslationsType extends AbstractType
             'locales' => $this->localeProvider->getLocales(),
             'default_locale' => $this->localeProvider->getDefaultLocale(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),
-            'fields' => array(),
-            'exclude_fields' => array(),
-        ));
+            'fields' => [],
+            'exclude_fields' => [],
+        ]);
     }
 
     // BC for SF < 2.7

--- a/Locale/DefaultProvider.php
+++ b/Locale/DefaultProvider.php
@@ -42,7 +42,7 @@ class DefaultProvider implements LocaleProviderInterface
      * @param       $defaultLocale
      * @param array $requiredLocales
      */
-    public function __construct(array $locales, $defaultLocale, array $requiredLocales = array())
+    public function __construct(array $locales, $defaultLocale, array $requiredLocales = [])
     {
         if (!in_array($defaultLocale, $locales)) {
             if (count($locales) > 0) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,66 +1,56 @@
-<?xml version="1.0" ?>
-
-<container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
+<?xml version="1.0"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="a2lix_translation_form.locales" />
-        <parameter key="a2lix_translation_form.required_locales" />
-
+        <parameter key="a2lix_translation_form.locales"/>
+        <parameter key="a2lix_translation_form.required_locales"/>
         <parameter key="a2lix_translation_form.default.service.translation.class">A2lix\TranslationFormBundle\TranslationForm\TranslationForm</parameter>
         <parameter key="a2lix_translation_form.default.service.parameter_locale_provider.class">A2lix\TranslationFormBundle\Locale\DefaultProvider</parameter>
-
         <parameter key="a2lix_translation_form.default.listener.translations.class">A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener</parameter>
         <parameter key="a2lix_translation_form.default.listener.translationsForms.class">A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener</parameter>
-
         <parameter key="a2lix_translation_form.default.type.translations.class">A2lix\TranslationFormBundle\Form\Type\TranslationsType</parameter>
         <parameter key="a2lix_translation_form.default.type.translationsFields.class">A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType</parameter>
         <parameter key="a2lix_translation_form.default.type.translationsForms.class">A2lix\TranslationFormBundle\Form\Type\TranslationsFormsType</parameter>
         <parameter key="a2lix_translation_form.default.type.translationsLocalesSelector.class">A2lix\TranslationFormBundle\Form\Type\TranslationsLocalesSelectorType</parameter>
         <parameter key="a2lix_translation_form.default.type.translatedEntity.class">A2lix\TranslationFormBundle\Form\Type\TranslatedEntityType</parameter>
     </parameters>
-
     <services>
         <!-- Services -->
         <service id="a2lix_translation_form.default.service.translation" class="%a2lix_translation_form.default.service.translation.class%">
-            <argument type="service" id="form.registry" />
-            <argument type="service" id="a2lix_translation_form.manager_registry" />
+            <argument type="service" id="form.registry"/>
+            <argument type="service" id="a2lix_translation_form.manager_registry"/>
         </service>
         <service id="a2lix_translation_form.default.service.parameter_locale_provider" class="%a2lix_translation_form.default.service.parameter_locale_provider.class%">
         </service>
-
         <!-- Listeners -->
         <service id="a2lix_translation_form.default.listener.translations" class="%a2lix_translation_form.default.listener.translations.class%">
-            <argument type="service" id="a2lix_translation_form.default.service.translation" />
+            <argument type="service" id="a2lix_translation_form.default.service.translation"/>
         </service>
         <service id="a2lix_translation_form.default.listener.translationsForms" class="%a2lix_translation_form.default.listener.translationsForms.class%">
         </service>
-
         <!-- Form Types -->
         <service id="a2lix_translation_form.default.type.translations" class="%a2lix_translation_form.default.type.translations.class%">
-            <argument type="service" id="a2lix_translation_form.default.listener.translations" />
-            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
-            <tag name="form.type" alias="a2lix_translations" />
+            <argument type="service" id="a2lix_translation_form.default.listener.translations"/>
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider"/>
+            <tag name="form.type" alias="a2lix_translations"/>
         </service>
         <service id="a2lix_translation_form.default.type.translationsFields" class="%a2lix_translation_form.default.type.translationsFields.class%">
-            <tag name="form.type" alias="a2lix_translationsFields" />
+            <tag name="form.type" alias="a2lix_translationsFields"/>
         </service>
         <service id="a2lix_translation_form.default.type.translationsForms" class="%a2lix_translation_form.default.type.translationsForms.class%">
-            <argument type="service" id="a2lix_translation_form.default.service.translation" />
-            <argument type="service" id="a2lix_translation_form.default.listener.translationsForms" />
-            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
-            <tag name="form.type" alias="a2lix_translationsForms" />
+            <argument type="service" id="a2lix_translation_form.default.service.translation"/>
+            <argument type="service" id="a2lix_translation_form.default.listener.translationsForms"/>
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider"/>
+            <tag name="form.type" alias="a2lix_translationsForms"/>
         </service>
         <service id="a2lix_translation_form.default.type.translationsLocalesSelector" class="%a2lix_translation_form.default.type.translationsLocalesSelector.class%">
-            <argument type="service" id="a2lix_translation_form.default.service.locale_provider" />
-            <tag name="form.type" alias="a2lix_translationsLocalesSelector" />
+            <argument type="service" id="a2lix_translation_form.default.service.locale_provider"/>
+            <tag name="form.type" alias="a2lix_translationsLocalesSelector"/>
         </service>
         <service id="a2lix_translation_form.default.type.translatedEntity" class="%a2lix_translation_form.default.type.translatedEntity.class%">
             <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" />
+                <argument type="service" id="request" on-invalid="null"/>
             </call>
-            <tag name="form.type" alias="a2lix_translatedEntity" />
+            <tag name="form.type" alias="a2lix_translatedEntity"/>
         </service>
     </services>
 </container>

--- a/Tests/DependencyInjection/A2lixTranslationFormExtensionTest.php
+++ b/Tests/DependencyInjection/A2lixTranslationFormExtensionTest.php
@@ -20,8 +20,8 @@ class A2lixTranslationFormExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
         $this->assertContainerBuilderHasParameter('a2lix_translation_form.locale_provider', 'default');
-        $this->assertContainerBuilderHasParameter('a2lix_translation_form.locales', array('es', 'en'));
-        $this->assertContainerBuilderHasParameter('a2lix_translation_form.required_locales', array());
+        $this->assertContainerBuilderHasParameter('a2lix_translation_form.locales', ['es', 'en']);
+        $this->assertContainerBuilderHasParameter('a2lix_translation_form.required_locales', []);
         $this->assertContainerBuilderHasParameter('a2lix_translation_form.default_locale', 'es');
         $this->assertContainerBuilderHasParameter(
             'a2lix_translation_form.templating',
@@ -32,16 +32,16 @@ class A2lixTranslationFormExtensionTest extends AbstractExtensionTestCase
 
     protected function getContainerExtensions()
     {
-        return array(
+        return [
             new A2lixTranslationFormExtension(),
-        );
+        ];
     }
 
     protected function getMinimalConfiguration()
     {
-        return array(
-            'locales' => array('es', 'en'),
+        return [
+            'locales' => ['es', 'en'],
             'default_locale' => 'es',
-        );
+        ];
     }
 }

--- a/Tests/Gedmo/Fixtures/Entity/Product.php
+++ b/Tests/Gedmo/Fixtures/Entity/Product.php
@@ -11,6 +11,7 @@
 
 namespace A2lix\TranslationFormBundle\Tests\Gedmo\Fixtures\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -45,7 +46,6 @@ class Product
     protected $url;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection
      * @ORM\OneToMany(targetEntity="Media", mappedBy="product", indexBy="locale", cascade={"all"}, orphanRemoval=true)
      * @Assert\Valid
      */
@@ -59,8 +59,8 @@ class Product
 
     public function __construct()
     {
-        $this->medias = new \Doctrine\Common\Collections\ArrayCollection();
-        $this->translations = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->medias = new ArrayCollection();
+        $this->translations = new ArrayCollection();
     }
 
     public function getId()

--- a/Tests/Gedmo/Form/TranslationsTypeTest.php
+++ b/Tests/Gedmo/Form/TranslationsTypeTest.php
@@ -29,23 +29,23 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
             $submitType = 'submit';
         }
 
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'fr' => array(
+            'translations' => [
+                'fr' => [
                     'title' => 'title fr',
                     'description' => 'desc fr',
-                ),
-                'en' => array(
+                ],
+                'en' => [
                     'title' => 'title en',
                     'description' => 'desc en',
-                ),
-                'de' => array(
+                ],
+                'de' => [
                     'title' => 'title de',
                     'description' => 'desc de',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $productTranslationFr = new ProductTranslation();
         $productTranslationFr->setLocale('fr')
@@ -82,23 +82,23 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
         //
         // Edition: Modify values
         //
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'fr' => array(
+            'translations' => [
+                'fr' => [
                     'title' => 'title frrrrrr',
                     'description' => 'desc fr',
-                ),
-                'en' => array(
+                ],
+                'en' => [
                     'title' => 'title en',
                     'description' => 'desc ennnnnnn',
-                ),
-                'de' => array(
+                ],
+                'de' => [
                     'title' => 'title de',
                     'description' => 'desc de',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $product->getTranslations()['fr']->setTitle('title frrrrrr');
         $product->getTranslations()['en']->setTitle('desc ennnnnnn');
 
@@ -111,13 +111,6 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
 
         $this->assertTrue($form->isSynchronized());
         $this->assertEquals($product, $form->getData());
-
-//        $view = $form->createView();
-//        $children = $view->children;
-//
-//        foreach (array_keys($formData) as $key) {
-//            $this->assertArrayHasKey($key, $children);
-//        }
     }
 
     public function testSubmitValidConfiguration1Data()
@@ -132,19 +125,19 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
             $submitType = 'submit';
         }
 
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'es' => array(
+            'translations' => [
+                'es' => [
                     'title' => 'title es',
                     'description' => 'desc es',
-                ),
-                'fr' => array(
+                ],
+                'fr' => [
                     'title' => 'title fr',
                     'description' => 'desc fr',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $productTranslationEs = new ProductTranslation();
         $productTranslationEs->setLocale('es')
@@ -165,9 +158,9 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
         //
         $form = $this->factory->createBuilder($formType, new Product())
             ->add('url')
-            ->add('translations', $translationsType, array(
-                'locales' => array('es', 'fr', 'de'),
-            ))
+            ->add('translations', $translationsType, [
+                'locales' => ['es', 'fr', 'de'],
+            ])
             ->add('save', $submitType)
             ->getForm();
         $form->submit($formData);
@@ -178,23 +171,23 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
         //
         // Edition: Add 'de' locale
         //
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'es' => array(
+            'translations' => [
+                'es' => [
                     'title' => 'title es',
                     'description' => 'desc es',
-                ),
-                'fr' => array(
+                ],
+                'fr' => [
                     'title' => 'title fr',
                     'description' => 'desc fr',
-                ),
-                'de' => array(
+                ],
+                'de' => [
                     'title' => 'title de',
                     'description' => 'desc de',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $productTranslationDe = new ProductTranslation();
         $productTranslationDe->setLocale('de')
                              ->setTitle('title de')
@@ -203,22 +196,15 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
 
         $form = $this->factory->createBuilder($formType, $product)
             ->add('url')
-            ->add('translations', $translationsType, array(
-                'locales' => array('es', 'fr', 'de'),
-            ))
+            ->add('translations', $translationsType, [
+                'locales' => ['es', 'fr', 'de'],
+            ])
             ->add('save', $submitType)
             ->getForm();
         $form->submit($formData);
 
         $this->assertTrue($form->isSynchronized());
         $this->assertEquals($product, $form->getData());
-
-//        $view = $form->createView();
-//        $children = $view->children;
-//
-//        foreach (array_keys($formData) as $key) {
-//            $this->assertArrayHasKey($key, $children);
-//        }
     }
 
     public function testSubmitValidConfiguration2Data()
@@ -233,20 +219,20 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
             $submitType = 'submit';
         }
 
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'fr' => array(
+            'translations' => [
+                'fr' => [
                     'title' => 'title fr',
-                ),
-                'en' => array(
+                ],
+                'en' => [
                     'title' => 'title en',
-                ),
-                'de' => array(
+                ],
+                'de' => [
                     'title' => 'title de',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
 
         $productTranslationFr = new ProductTranslation();
         $productTranslationFr->setLocale('fr')
@@ -269,16 +255,16 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
         //
         $form = $this->factory->createBuilder($formType, new Product())
             ->add('url')
-            ->add('translations', $translationsType, array(
-                'fields' => array(
-                    'title' => array(
+            ->add('translations', $translationsType, [
+                'fields' => [
+                    'title' => [
                         'label' => 'name',
-                    ),
-                    'description' => array(
+                    ],
+                    'description' => [
                         'display' => false,
-                    ),
-                ),
-            ))
+                    ],
+                ],
+            ])
             ->add('save', $submitType)
             ->getForm();
         $form->submit($formData);
@@ -289,56 +275,49 @@ class TranslationsTypeTest extends TranslationsTypeTestCase
         //
         // Edition: Add field
         //
-        $formData = array(
+        $formData = [
             'url' => 'a2lix.fr',
-            'translations' => array(
-                'fr' => array(
+            'translations' => [
+                'fr' => [
                     'title' => 'title fr',
                     'description' => 'desc fr',
-                ),
-                'en' => array(
+                ],
+                'en' => [
                     'title' => 'title en',
                     'description' => 'desc en',
-                ),
-                'de' => array(
+                ],
+                'de' => [
                     'title' => 'title de',
                     'description' => 'desc de',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         $product->getTranslations()['fr']->setDescription('desc fr');
         $product->getTranslations()['en']->setDescription('desc en');
         $product->getTranslations()['de']->setDescription('desc de');
 
         $form = $this->factory->createBuilder($formType, $product)
             ->add('url')
-            ->add('translations', $translationsType, array(
-                'fields' => array(
-                    'title' => array(
+            ->add('translations', $translationsType, [
+                'fields' => [
+                    'title' => [
                         'label' => 'name',
-                    ),
-                ),
-            ))
+                    ],
+                ],
+            ])
             ->add('save', $submitType)
             ->getForm();
         $form->submit($formData);
 
         $this->assertTrue($form->isSynchronized());
         $this->assertEquals($product, $form->getData());
-
-//        $view = $form->createView();
-//        $children = $view->children;
-//
-//        foreach (array_keys($formData) as $key) {
-//            $this->assertArrayHasKey($key, $children);
-//        }
     }
 
     protected function getUsedEntityFixtures()
     {
-        return array(
+        return [
             'A2lix\\TranslationFormBundle\\Tests\\Gedmo\\Fixtures\\Entity\\Product',
             'A2lix\\TranslationFormBundle\\Tests\\Gedmo\\Fixtures\\Entity\\ProductTranslation',
-        );
+        ];
     }
 }

--- a/Tests/Locale/DefaultProviderTest.php
+++ b/Tests/Locale/DefaultProviderTest.php
@@ -25,9 +25,9 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->locales = array('es', 'en', 'pt');
+        $this->locales = ['es', 'en', 'pt'];
         $this->defaultLocale = 'en';
-        $this->requiredLocales = array('es', 'en');
+        $this->requiredLocales = ['es', 'en'];
 
         $this->provider = new DefaultProvider($this->locales, $this->defaultLocale, $this->requiredLocales);
     }
@@ -50,7 +50,7 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
         // now call the constructor
         $reflectedClass = new \ReflectionClass($classname);
         $constructor = $reflectedClass->getConstructor();
-        $constructor->invoke($mock, array('es', 'en'), 'de', array());
+        $constructor->invoke($mock, ['es', 'en'], 'de', []);
     }
 
     public function testRequiredLocaleAreInLocales()
@@ -70,7 +70,7 @@ class DefaultProviderTest extends \PHPUnit_Framework_TestCase
         // now call the constructor
         $reflectedClass = new \ReflectionClass($classname);
         $constructor = $reflectedClass->getConstructor();
-        $constructor->invoke($mock, array('es', 'en'), 'en', array('en', 'pt'));
+        $constructor->invoke($mock, ['es', 'en'], 'en', ['en', 'pt']);
     }
 
     public function testGetLocales()

--- a/Tests/TranslationsTypeTestCase.php
+++ b/Tests/TranslationsTypeTestCase.php
@@ -11,6 +11,13 @@
 
 namespace A2lix\TranslationFormBundle\Tests;
 
+use A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener;
+use A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener;
+use A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType;
+use A2lix\TranslationFormBundle\Form\Type\TranslationsFormsType;
+use A2lix\TranslationFormBundle\Form\Type\TranslationsType;
+use A2lix\TranslationFormBundle\Locale\DefaultProvider;
+use A2lix\TranslationFormBundle\TranslationForm\TranslationForm;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;
@@ -72,7 +79,7 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
 
         parent::setUp();
 
-        $formExtensions = array(new DoctrineOrmExtension($this->emRegistry));
+        $formExtensions = [new DoctrineOrmExtension($this->emRegistry)];
         $resolvedFormTypeFactory = $this->getMockBuilder('Symfony\Component\Form\ResolvedFormTypeFactory')
             ->disableOriginalConstructor()
             ->getMock();
@@ -82,9 +89,9 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
             $resolvedFormTypeFactory
         );
 
-        $translationForm = new \A2lix\TranslationFormBundle\TranslationForm\TranslationForm($formRegistry, $this->emRegistry);
-        $translationsListener = new \A2lix\TranslationFormBundle\Form\EventListener\TranslationsListener($translationForm);
-        $translationsFormsListener = new \A2lix\TranslationFormBundle\Form\EventListener\TranslationsFormsListener();
+        $translationForm = new TranslationForm($formRegistry, $this->emRegistry);
+        $translationsListener = new TranslationsListener($translationForm);
+        $translationsFormsListener = new TranslationsFormsListener();
 
         if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
             $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
@@ -98,7 +105,7 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
 
         $validator->expects($this->any())
             ->method('validate')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
 
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions(
@@ -110,18 +117,15 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
                      ->disableOriginalConstructor()
                      ->getMock()
             )
-            ->addTypes(array(
-                new \A2lix\TranslationFormBundle\Form\Type\TranslationsType(
-                    $translationsListener,
-                    new \A2lix\TranslationFormBundle\Locale\DefaultProvider(array('fr', 'en', 'de'), 'en')
-                ),
-                new \A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType(),
-                new \A2lix\TranslationFormBundle\Form\Type\TranslationsFormsType(
+            ->addTypes([
+                new TranslationsType($translationsListener, new DefaultProvider(['fr', 'en', 'de'], 'en')),
+                new TranslationsFieldsType(),
+                new TranslationsFormsType(
                     $translationForm,
                     $translationsFormsListener,
-                    new \A2lix\TranslationFormBundle\Locale\DefaultProvider(array('fr', 'en', 'de'), 'en')
+                    new DefaultProvider(['fr', 'en', 'de'], 'en')
                 ),
-            ))
+            ])
             ->getFormFactory();
 
         $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
@@ -140,7 +144,7 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
 
     protected function getUsedEntityFixtures()
     {
-        return array();
+        return [];
     }
 
     protected function persist(array $entities)
@@ -164,6 +168,6 @@ abstract class TranslationsTypeTestCase extends TypeTestCase
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))
                   ->will($this->returnValue($em));
 
-        return new Registry($container, array(), array('default' => 'doctrine.orm.default_entity_manager'), 'default', 'default');
+        return new Registry($container, [], ['default' => 'doctrine.orm.default_entity_manager'], 'default', 'default');
     }
 }

--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -25,8 +25,8 @@ class TranslationForm implements TranslationFormInterface
     private $managerRegistry;
 
     /**
-     * @param \Symfony\Component\Form\FormRegistry         $formRegistry
-     * @param \Doctrine\Common\Persistence\ManagerRegistry $managerRegistry
+     * @param FormRegistry    $formRegistry
+     * @param ManagerRegistry $managerRegistry
      */
     public function __construct(FormRegistry $formRegistry, ManagerRegistry $managerRegistry)
     {
@@ -39,10 +39,10 @@ class TranslationForm implements TranslationFormInterface
      */
     public function getFieldsOptions($class, $options)
     {
-        $fieldsOptions = array();
+        $fieldsOptions = [];
 
         foreach ($this->getFieldsList($options, $class) as $field) {
-            $fieldOptions = isset($options['fields'][$field]) ? $options['fields'][$field] : array();
+            $fieldOptions = isset($options['fields'][$field]) ? $options['fields'][$field] : [];
 
             if (!isset($fieldOptions['display']) || $fieldOptions['display']) {
                 $fieldOptions = $this->guessMissingFieldOptions($this->typeGuesser, $class, $field, $fieldOptions);
@@ -53,7 +53,7 @@ class TranslationForm implements TranslationFormInterface
                     unset($fieldOptions['locale_options']);
 
                     foreach ($options['locales'] as $locale) {
-                        $localeFieldOptions = isset($localesFieldOptions[$locale]) ? $localesFieldOptions[$locale] : array();
+                        $localeFieldOptions = isset($localesFieldOptions[$locale]) ? $localesFieldOptions[$locale] : [];
                         if (!isset($localeFieldOptions['display']) || $localeFieldOptions['display']) {
                             $fieldsOptions[$locale][$field] = $localeFieldOptions + $fieldOptions;
                         }
@@ -76,7 +76,7 @@ class TranslationForm implements TranslationFormInterface
      */
     public function getFormsOptions($options)
     {
-        $formsOptions = array();
+        $formsOptions = [];
 
         // Current options
         $formOptions = $options['form_options'];
@@ -87,7 +87,7 @@ class TranslationForm implements TranslationFormInterface
             unset($formOptions['locale_options']);
 
             foreach ($options['locales'] as $locale) {
-                $localeFormOptions = isset($localesFormOptions[$locale]) ? $localesFormOptions[$locale] : array();
+                $localeFormOptions = isset($localesFormOptions[$locale]) ? $localesFormOptions[$locale] : [];
                 if (!isset($localeFormOptions['display']) || $localeFormOptions['display']) {
                     $formsOptions[$locale] = $localeFormOptions + $formOptions;
                 }
@@ -137,16 +137,16 @@ class TranslationForm implements TranslationFormInterface
      *
      * @return array
      */
-    protected function getTranslationFields($translationClass, array $exclude = array())
+    protected function getTranslationFields($translationClass, array $exclude = [])
     {
-        $fields = array();
+        $fields = [];
         $translationClass = ClassUtils::getRealClass($translationClass);
 
         if ($manager = $this->managerRegistry->getManagerForClass($translationClass)) {
             $metadataClass = $manager->getMetadataFactory()->getMetadataFor($translationClass);
 
             foreach ($metadataClass->fieldMappings as $fieldMapping) {
-                if (!in_array($fieldMapping['fieldName'], array('id', 'locale')) && !in_array($fieldMapping['fieldName'], $exclude)) {
+                if (!in_array($fieldMapping['fieldName'], ['id', 'locale']) && !in_array($fieldMapping['fieldName'], $exclude)) {
                     $fields[] = $fieldMapping['fieldName'];
                 }
             }

--- a/Util/Gedmo/EventListener/LocaleListener.php
+++ b/Util/Gedmo/EventListener/LocaleListener.php
@@ -24,7 +24,7 @@ class LocaleListener implements EventSubscriberInterface
     private $translatableListener;
 
     /**
-     * @param \Gedmo\Translatable\TranslatableListener $translatableListener
+     * @param TranslatableListener $translatableListener
      */
     public function __construct(TranslatableListener $translatableListener)
     {
@@ -32,7 +32,7 @@ class LocaleListener implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param GetResponseEvent $event
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
@@ -41,8 +41,8 @@ class LocaleListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array(
-            KernelEvents::REQUEST => array('onKernelRequest', -10),
-        );
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', -10],
+        ];
     }
 }

--- a/Util/Gedmo/config/gedmo.xml
+++ b/Util/Gedmo/config/gedmo.xml
@@ -1,17 +1,12 @@
-<?xml version="1.0" ?>
-
-<container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
+<?xml version="1.0"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="a2lix_translation_form.gedmo.listener.locale.class">A2lix\TranslationFormBundle\Util\Gedmo\EventListener\LocaleListener</parameter>
     </parameters>
-
     <services>
         <service id="a2lix_translation_form.gedmo.listener.locale" class="%a2lix_translation_form.gedmo.listener.locale.class%">
-            <argument type="service" id="gedmo.listener.translatable" />
-            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="gedmo.listener.translatable"/>
+            <tag name="kernel.event_subscriber"/>
         </service>
     </services>
 </container>

--- a/Util/LegacyFormHelper.php
+++ b/Util/LegacyFormHelper.php
@@ -13,13 +13,13 @@ namespace A2lix\TranslationFormBundle\Util;
 
 final class LegacyFormHelper
 {
-    private static $map = array(
+    private static $map = [
         'A2lix\TranslationFormBundle\Form\Type\TranslationsType' => 'a2lix_translations',
         'A2lix\TranslationFormBundle\Form\Type\TranslationsFieldsType' => 'a2lix_translationsFields',
         'A2lix\TranslationFormBundle\Form\Type\TranslationsFormsType' => 'a2lix_translationsForms',
         'A2lix\TranslationFormBundle\Form\Type\TranslatedEntityType' => 'a2lix_translatedEntity',
         'A2lix\TranslationFormBundle\Form\Type\TranslationsLocalesSelectorType' => 'a2lix_translationsLocalesSelector',
-    );
+    ];
 
     private function __construct()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because this is pedantinc.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
- Added short array syntax, as we have php5.4 as minimum, we can use short array safely.
- Enabled xmllint on flintCI
- Minor code style improvements

All this should improve or minimize merge issues on master