### PR TITLE
Fix parent form type on SF3

### DIFF
--- a/Form/Type/TranslatedEntityType.php
+++ b/Form/Type/TranslatedEntityType.php
@@ -63,7 +63,10 @@ class TranslatedEntityType extends AbstractType
 
     public function getParent()
     {
-        return 'entity';
+        return
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Bridge\Doctrine\Form\Type\EntityType' :
+            'entity';
     }
 
     // BC for SF < 3.0

--- a/Form/Type/TranslationsLocalesSelectorType.php
+++ b/Form/Type/TranslationsLocalesSelectorType.php
@@ -67,7 +67,10 @@ class TranslationsLocalesSelectorType extends AbstractType
 
     public function getParent()
     {
-        return 'choice';
+        return
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Symfony\Component\Form\Extension\Core\Type\ChoiceType' :
+            'choice';
     }
 
     // BC for SF < 3.0


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Usage of FQCNs for form types to improve SF3 compatibility
```

## Subject

<!-- Describe your Pull Request content here -->
getParent should use FQCNs when possible, to avoid warnings/errors on SF3