### PR TITLE
Remove call to setRequest

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -47,9 +47,11 @@
             <tag name="form.type" alias="a2lix_translationsLocalesSelector"/>
         </service>
         <service id="a2lix_translation_form.default.type.translatedEntity" class="%a2lix_translation_form.default.type.translatedEntity.class%">
-            <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null"/>
+            <!-- Uncomment this when dropping support for SF 2.3
+            <call method="setRequestStack">
+                <argument type="service" id="request_stack"/>
             </call>
+            -->
             <tag name="form.type" alias="a2lix_translatedEntity"/>
         </service>
     </services>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove call to `setRequest` on the xml configuration fixes scope widening
```

## Subject

<!-- Describe your Pull Request content here -->
it is done on the bundle extension conditionally. Will be "setRequestStack" when RequestStack is available otherwise "setRequest"