### PR TITLE
Improved upgrade guide

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -12,7 +12,7 @@ If using Symfony 4
 
 return [
     // ...
-    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    A2lix\AutoFormBundle\A2lixAutoFormBundle::class => ['all' => true],
     // ...
 ];
 ```

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -76,3 +76,16 @@ You also have to register this compiler pass in your Kernel.
 
 See [How to Work with Compiler Passes](https://symfony.com/doc/current/service_container/compiler_passes.html)
 in Symfony docs for more details.
+
+### 5. Bootstrap 4
+Translations form template provided with v3 of this bundle requires Bootstrap v4. If you are using Bootstrap v3
+and cannot upgrade at the moment, you should consider using custom template.
+In particular this is the case when you're using TranslationFormBundle with SonataAdmin, which ships with
+Bootstrap v3.
+
+You can copy `default.html.twig` template from `2.x` branch into your app or create your own template
+and configure translation form to use it:
+```yaml
+a2lix_translation_form:
+  templating: "Translation/bootstrap_3_layout.html.twig"
+```

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,6 +1,78 @@
 UPGRADE FROM 2.x to 3.x
 =======================
 
-### [BC Break] ````new A2lix\AutoFormBundle\A2lixAutoFormBundle()```` is required as additional Bundle in your AppKernel.
+## BC Breaks
 
-### [BC Break] ````manager_registry```` option is no longer part of the ````a2lix_translation_form```` configuration file.
+### 1. New bundle requirements
+```A2lix\AutoFormBundle\A2lixAutoFormBundle``` is required as an additional Bundle in your AppKernel.
+
+If using Symfony 4
+```php
+// config/bundles.php
+
+return [
+    // ...
+    Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
+    // ...
+];
+```
+
+If using Symfony 3
+```php
+// app/AppKernel.php
+
+public function registerBundles()
+{
+    return [
+        // ...
+        new A2lix\AutoFormBundle\A2lixAutoFormBundle(),
+        // ...
+    ];
+}
+```
+
+### 2. Config
+```manager_registry``` option is no longer part of the ```a2lix_translation_form``` configuration file.
+
+### 3. Creating forms with FormBuilder
+```exclude_fields``` form option of `A2lix\TranslationFormBundle\Form\Type\TranslationsType`
+was renamed to ```excluded_fields```.
+
+You should fix all usages of this option otherwise exception will be thrown when building the form.
+
+```php
+$builder->add('translations', TranslationsType::class, [
+    'excluded_fields' => ['details'], // use correct option name
+]);
+```
+
+### 4. Overriding / extending services
+Version 2 used parameters like `a2lix_translation_form.default.*.translations.class` to configure listeners, form types
+and other services and you could override service classes by simply setting those parameters values in your app.
+
+**Version 3 does not provide those parameters anymore**, so if you want to override any service provided by this bundle,
+you have to do it in a compiler pass. E. g.:
+```php
+<?php
+
+namespace App\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OverrideServiceCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('a2lix_translation_form.form.event_listener.translations_listener')) {
+            // change service definition to use your own implementation of TranslationsListener
+            $container->getDefinition('a2lix_translation_form.form.event_listener.translations_listener')
+                ->setClass(\App\EventListener\TranslationsListener::class);
+        }
+    }
+}
+```
+You also have to register this compiler pass in your Kernel.
+
+See [How to Work with Compiler Passes](https://symfony.com/doc/current/service_container/compiler_passes.html)
+in Symfony docs for more details.


### PR DESCRIPTION
I am targeting this branch, because it's an improvement for 2.0 -> 3.0 upgrade guide.

## Changelog

```markdown
### Changed
- Improved upgrade guide from 2.0 to 3.0
```

## Subject

I faced some not documented upgrading issues while upgrading to version 3 of this bundle. I think this upgrade guide improvement will be useful for others.