### PR TITLE
Fix default tab opening

### DIFF
--- a/src/Resources/views/bootstrap_4_layout.html.twig
+++ b/src/Resources/views/bootstrap_4_layout.html.twig
@@ -6,11 +6,13 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
-                    {{ translationsFields.vars.label|default(locale|humanize)|trans }}
-                    {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
-                    {% if translationsFields.vars.required %}*{% endif %}
+            <li class="nav-item {% if app.request.locale == locale %} active{% endif %}">
+                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link" data-toggle="tab" role="tab">
+                    {% block locale_tab_title %}
+                        {{ translationsFields.vars.label|default(locale|humanize)|trans }}
+                        {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
+                        {% if translationsFields.vars.required %}*{% endif %}
+                    {% endblock %}
                 </a>
             </li>
         {% endfor %}
@@ -20,7 +22,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
I am targeting this branch, because this is a bug introduced in 3.x

## Changelog
 + Add a twig block to override the language tab title (#262)

## Subject
In 3.x, on page load, the current locale tab is not properly open: tab title not focused and content always displayed, even when another tab is selected.