### PR TITLE
Remove empty KNP translations on form submit

### DIFF
--- a/src/Form/EventListener/TranslationsListener.php
+++ b/src/Form/EventListener/TranslationsListener.php
@@ -71,7 +71,9 @@ class TranslationsListener implements EventSubscriberInterface
 
         foreach ($data as $locale => $translation) {
             // Remove useless Translation object
-            if (empty($translation)) {
+            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty()) // Knp
+                || empty($translation) // Default
+            ) {
                 $data->removeElement($translation);
                 continue;
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because it fix the issue #320 by removing correctly the KNP empty translations.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #320 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed

Remove correctly the KNP empty translations

```

## Subject

<!-- Describe your Pull Request content here -->

Use the method `isEmpty()` instead of `empty()` for [KNP translatable](https://github.com/KnpLabs/DoctrineBehaviors#translatable)
