### PR TITLE
Fix root node deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
   - nightly
 
 sudo: false
@@ -29,28 +30,28 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '5.4'
+    - php: '5.6'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.0'
       env: SYMFONY=2.3.*
-    - php: '7.2'
+    - php: '7.0'
       env: SYMFONY=2.7.*
-    - php: '7.2'
+    - php: '7.0'
       env: SYMFONY=2.8.*
-    - php: '7.2'
-      env: SYMFONY=3.3.*
-    - php: '7.2'
+    - php: '7.3'
       env: SYMFONY=3.4.*
-    - php: '7.2'
-      env: SYMFONY=4.0.*
-    - php: '7.2'
-      env: SYMFONY='dev-master as 4.1.x-dev'
-    - php: '7.2'
+    - php: '7.3'
+      env: SYMFONY=4.1.*
+    - php: '7.3'
+      env: SYMFONY=4.2.*
+    - php: '7.3'
+      env: SYMFONY='dev-master as 4.3.x-dev'
+    - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0
-    - env: SYMFONY='dev-master as 4.1.x-dev'
+    - env: SYMFONY='dev-master as 4.3.x-dev'
 
 before_install:
   - echo memory_limit = -1 >> $HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;

--- a/DependencyInjection/Compiler/TemplatingPass.php
+++ b/DependencyInjection/Compiler/TemplatingPass.php
@@ -24,7 +24,7 @@ class TemplatingPass implements CompilerPassInterface
         if (false !== ($template = $container->getParameter('a2lix_translation_form.templating'))) {
             $resources = $container->getParameter('twig.form.resources');
 
-            if (!in_array($template, $resources)) {
+            if (!\in_array($template, $resources)) {
                 $resources[] = $template;
                 $container->setParameter('twig.form.resources', $resources);
             }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('a2lix_translation_form');
-        
+
         // Keep compatibility with symfony/config < 4.2
         if (!method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->root('a2lix_translation_form');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,8 +25,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('a2lix_translation_form');
+        $treeBuilder = new TreeBuilder('a2lix_translation_form');
+        
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->root('a2lix_translation_form');
+        } else {
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         $rootNode
             ->children()

--- a/Form/EventListener/TranslationsListener.php
+++ b/Form/EventListener/TranslationsListener.php
@@ -54,7 +54,7 @@ class TranslationsListener implements EventSubscriberInterface
                         [
                             'data_class' => $translationClass,
                             'fields' => $fieldsOptions[$locale],
-                            'required' => in_array($locale, $formOptions['required_locales']),
+                            'required' => \in_array($locale, $formOptions['required_locales']),
                         ]
                     );
                 }

--- a/Form/Type/TranslatedEntityType.php
+++ b/Form/Type/TranslatedEntityType.php
@@ -47,7 +47,7 @@ class TranslatedEntityType extends AbstractType
     {
         // BC for SF < 2.7
         $optionProperty = 'choice_label';
-        if (in_array('property', $resolver->getDefinedOptions())) {
+        if (\in_array('property', $resolver->getDefinedOptions())) {
             $optionProperty = 'property';
         }
 

--- a/Form/Type/TranslationsFormsType.php
+++ b/Form/Type/TranslationsFormsType.php
@@ -59,7 +59,7 @@ class TranslationsFormsType extends AbstractType
         foreach ($options['locales'] as $locale) {
             if (isset($formsOptions[$locale])) {
                 $builder->add($locale, $options['form_type'],
-                    $formsOptions[$locale] + ['required' => in_array($locale, $options['required_locales'])]
+                    $formsOptions[$locale] + ['required' => \in_array($locale, $options['required_locales'])]
                 );
             }
         }

--- a/Locale/DefaultProvider.php
+++ b/Locale/DefaultProvider.php
@@ -44,8 +44,8 @@ class DefaultProvider implements LocaleProviderInterface
      */
     public function __construct(array $locales, $defaultLocale, array $requiredLocales = [])
     {
-        if (!in_array($defaultLocale, $locales)) {
-            if (count($locales) > 0) {
+        if (!\in_array($defaultLocale, $locales)) {
+            if (\count($locales) > 0) {
                 throw new \InvalidArgumentException(sprintf('Default locale `%s` not found within the configured locales `[%s]`. Perhaps you need to add it to your `a2lix_translation_form.locales` bundle configuration?', $defaultLocale, implode(',', $locales)));
             }
 

--- a/TranslationForm/TranslationForm.php
+++ b/TranslationForm/TranslationForm.php
@@ -146,7 +146,7 @@ class TranslationForm implements TranslationFormInterface
             $metadataClass = $manager->getMetadataFactory()->getMetadataFor($translationClass);
 
             foreach ($metadataClass->fieldMappings as $fieldMapping) {
-                if (!in_array($fieldMapping['fieldName'], ['id', 'locale']) && !in_array($fieldMapping['fieldName'], $exclude)) {
+                if (!\in_array($fieldMapping['fieldName'], ['id', 'locale']) && !\in_array($fieldMapping['fieldName'], $exclude)) {
                     $fields[] = $fieldMapping['fieldName'];
                 }
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove deprecation messages when using `symfony/config ^4.2`
```

## Subject

<!-- Describe your Pull Request content here -->
This allows using Symfony 4.2 without getting a lot of deprecation messages