### PR TITLE
Translations fields in fieldNames are not being filtered

### DIFF
--- a/src/Resources/views/macros.html.twig
+++ b/src/Resources/views/macros.html.twig
@@ -31,8 +31,7 @@ Example:
 
             <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
             {% for translationsField in translationsFields if translationsField.vars.name in fieldsNames %}
-                {{ form_errors(translationsFields) }}
-                {{ form_widget(translationsFields) }}
+                {{ form_row(translationsField) }}
             {% endfor %}
             </div>
         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because it's the branch where the error is located. It's ok in the equivalent file in 2.x branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Typo in variable reference
- Rendering the complete form row (label was being omitted)

## Subject
```

<!-- Describe your Pull Request content here -->
All fields were being rendered, not only those especified in `fieldsNames`.
There's an errata in the rendering (an extra 's' in `translationsFields`).

Also, labels where not being rendered nor row rendering could be customized.

