### PR TITLE
Expose default value of 'form_type'

### DIFF
--- a/src/Form/Type/TranslationsFormsType.php
+++ b/src/Form/Type/TranslationsFormsType.php
@@ -58,6 +58,7 @@ class TranslationsFormsType extends AbstractType
             'locales' => $this->localeProvider->getLocales(),
             'default_locale' => $this->localeProvider->getDefaultLocale(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),
+            'form_type' => null,
             'form_options' => [],
         ]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because there is a bug during implement TranslationsFormsType.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #327

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- src/Form/Type/TranslationsFormsType.php
### Fixed
- src/Form/Type/TranslationsFormsType.php
```

## Subject

<!-- Describe your Pull Request content here -->
Expose default value of 'form_type' to prevent `The required option "form_type" is missing.` exception also when this value is passed