### PR TITLE
Fix KNP empty translations still persisted 2

### DIFF
--- a/src/Form/EventListener/TranslationsFormsListener.php
+++ b/src/Form/EventListener/TranslationsFormsListener.php
@@ -47,7 +47,9 @@ class TranslationsFormsListener implements EventSubscriberInterface
 
         foreach ($data as $locale => $translation) {
             // Remove useless Translation object
-            if (empty($translation)) {
+            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty()) // Knp
+                || empty($translation) // Default
+            ) {
                 $data->removeElement($translation);
                 continue;
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
