### PR TITLE
First active tab stays visible and not selected

### DIFF
--- a/src/Resources/views/bootstrap_4_layout.html.twig
+++ b/src/Resources/views/bootstrap_4_layout.html.twig
@@ -6,8 +6,8 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+            <li class="nav-item {% if app.request.locale == locale %}active{% endif %}">
+                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link" data-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -20,7 +20,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
Removed show class from tab pane and added active class to the li instead of a tag
This fixes a small bug on interface. Actually tab is not selected when first showed and when selecting another tab, first tabs content stays visible

Sorry for PR template, don't have time, if you don't want to merge, up to you. I have a workaround by overriding template in my code.

Anyway thanks for this bundle ! Great job