### PR TITLE
Tab kept showing after switching to another tab

### DIFF
--- a/src/Resources/views/bootstrap_4_layout.html.twig
+++ b/src/Resources/views/bootstrap_4_layout.html.twig
@@ -20,7 +20,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>


### PR DESCRIPTION
The default tab content kept showing even after switching to another tab as the "show" class isn't toggled by the switched. "show" class removed, seems to be working as expected now.