### PR TITLE
Fix tabs display

### DIFF
--- a/src/Resources/views/bootstrap_4_layout.html.twig
+++ b/src/Resources/views/bootstrap_4_layout.html.twig
@@ -6,8 +6,8 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+            <li class="nav-item {% if app.request.locale == locale %}active{% endif %}">
+                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link" data-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -20,7 +20,7 @@
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
                 {{ form_errors(translationsFields) }}
                 {{ form_widget(translationsFields) }}
             </div>

--- a/src/Resources/views/macros.html.twig
+++ b/src/Resources/views/macros.html.twig
@@ -15,8 +15,8 @@ Example:
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+            <li class="nav-item {% if app.request.locale == locale %}active{% endif %}">
+                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link" data-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -29,7 +29,7 @@ Example:
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
             {% for translationsField in translationsFields|filter(translationsField => translationsField.vars.name in fieldsNames) %}
                 {{ form_row(translationsField) }}
             {% endfor %}


### PR DESCRIPTION
There are two problems : 
- when the form is first displayed, no tab seems to be selected
- when switching to another locale, the current locale content is always displayed

This includes two fixes : 
- for the tab : class "active" should be placed on the ".nav-item" and not on the ".nav-link" 
=> when the form is displayed, you can now see that the current locale tab is selected

- for the content : remove class "show" on the ".tab-pane" 
=> when switching locales, you can now see only the content of the selected locale
=> same fix as #342 

-----
Two checks failed but it is not linked to this PR : 
Parse error: syntax error, unexpected 'string' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in /__w/TranslationFormBundle/TranslationFormBundle/vendor/ocramius/package-versions/src/PackageVersions/Installer.php on line 34