### PR TITLE
Fix multiple partial translations

### DIFF
--- a/src/Resources/views/macros.html.twig
+++ b/src/Resources/views/macros.html.twig
@@ -16,7 +16,7 @@ Example:
             {% set locale = translationsFields.vars.name %}
 
             <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+                <a href="#{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
@@ -29,7 +29,7 @@ Example:
         {% for translationsFields in form %}
             {% set locale = translationsFields.vars.name %}
 
-            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+            <div id="{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
             {% for translationsField in translationsFields|filter(translationsField => translationsField.vars.name in fieldsNames) %}
                 {{ form_row(translationsField) }}
             {% endfor %}

--- a/src/Resources/views/macros_bootstrap_4.html.twig
+++ b/src/Resources/views/macros_bootstrap_4.html.twig
@@ -1,6 +1,6 @@
 {#
 Example:
-{% import "@A2lixTranslationForm/macros_bootstrap_3.html.twig" as a2lixTranslations %}
+{% import "@A2lixTranslationForm/macros_bootstrap_4.html.twig" as a2lixTranslations %}
 {{ a2lixTranslations.partialTranslations(editForm.translations, ['title','description']) }}
 {{ a2lixTranslations.partialTranslations(editForm.translations, ['url']) }}
 #}

--- a/src/Resources/views/macros_bootstrap_5.html.twig
+++ b/src/Resources/views/macros_bootstrap_5.html.twig
@@ -1,6 +1,6 @@
 {#
 Example:
-{% import "@A2lixTranslationForm/macros_bootstrap_3.html.twig" as a2lixTranslations %}
+{% import "@A2lixTranslationForm/macros_bootstrap_5.html.twig" as a2lixTranslations %}
 {{ a2lixTranslations.partialTranslations(editForm.translations, ['title','description']) }}
 {{ a2lixTranslations.partialTranslations(editForm.translations, ['url']) }}
 #}


### PR DESCRIPTION
With this example we have a conflict id on the tab : 

```
{{ a2lixTranslations.partialTranslations(form.translations, ['name']) }}
...
{{ a2lixTranslations.partialTranslations(form.translations, ['feedbackPositive', 'feedbackNegative']) }}
```

With this PR, we no longer have the same id.