### PR TITLE
compatibility with easycorp/easyadmin-bundle v3.4.2 and so bootstrap5

### DIFF
--- a/src/Resources/views/bootstrap_5_layout.html.twig
+++ b/src/Resources/views/bootstrap_5_layout.html.twig
@@ -1,0 +1,34 @@
+{% block a2lix_translations_widget %}
+    {{ form_errors(form) }}
+    <div class="a2lix_translations">
+        <ul class="a2lix_translationsLocales nav nav-tabs" role="tablist">
+        {% for translationsFields in form %}
+            {% set locale = translationsFields.vars.name %}
+
+            <li class="nav-item" role="presentation">
+                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-bs-toggle="tab" role="tab">
+                    {{ translationsFields.vars.label|default(locale|humanize)|trans }}
+                    {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
+                    {% if translationsFields.vars.required %}*{% endif %}
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+
+        <div class="a2lix_translationsFields tab-content">
+        {% for translationsFields in form %}
+            {% set locale = translationsFields.vars.name %}
+
+            <div id="{{ translationsFields.vars.id }}_a2lix_translations-fields" class="tab-pane {% if app.request.locale == locale %}show active{% endif %} {% if not form.vars.valid %}sonata-ba-field-error{% endif %}" role="tabpanel">
+                {{ form_errors(translationsFields) }}
+                {{ form_widget(translationsFields) }}
+            </div>
+        {% endfor %}
+        </div>
+    </div>
+    
+{% endblock %}
+
+{% block a2lix_translationsForms_widget %}
+    {{ block('a2lix_translations_widget') }}
+{% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because it's logics...

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes none issue... i had a problem a contribute... you can change after if you wants, but in new version

the tabs didn't work anymore with new version of easyadmin from 3 days ago

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

add file src/Resources/views/bootstrap_5_layout.html.twig

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
add file src/Resources/views/bootstrap_5_layout.html.twig

### Changed

nothing else

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
