### PR TITLE
Add translatable locale labels (Should fix #262)

### DIFF
--- a/src/Form/EventListener/TranslationsListener.php
+++ b/src/Form/EventListener/TranslationsListener.php
@@ -57,6 +57,7 @@ class TranslationsListener implements EventSubscriberInterface
 
             $form->add($locale, AutoFormType::class, [
                 'data_class' => $translationClass,
+                'label' => $formOptions['locale_labels'][$locale] ?? null,
                 'required' => \in_array($locale, $formOptions['required_locales'], true),
                 'block_name' => ('field' === $formOptions['theming_granularity']) ? 'locale' : null,
                 'fields' => $fieldsOptions[$locale],

--- a/src/Form/Type/TranslationsType.php
+++ b/src/Form/Type/TranslationsType.php
@@ -53,6 +53,7 @@ class TranslationsType extends AbstractType
             'empty_data' => function (FormInterface $form) {
                 return new ArrayCollection();
             },
+            'locale_labels' => null,
             'locales' => $this->localeProvider->getLocales(),
             'default_locale' => $this->localeProvider->getDefaultLocale(),
             'required_locales' => $this->localeProvider->getRequiredLocales(),

--- a/tests/Form/Type/TranslationsTypeAdvancedTest.php
+++ b/tests/Form/Type/TranslationsTypeAdvancedTest.php
@@ -75,6 +75,26 @@ final class TranslationsTypeAdvancedTest extends TypeTestCase
         static::assertEquals(['title'], array_keys($translationsForm['de']->all()), 'Fields should not contains description');
     }
 
+    public function testLabels(): void
+    {
+        $form = $this->factory->createBuilder(FormType::class, new Product())
+            ->add('url')
+            ->add('translations', TranslationsType::class, [
+                'locale_labels' => [
+                    'fr' => 'Français',
+                    'en' => 'English',
+                ]
+            ])
+            ->add('save', SubmitType::class)
+            ->getForm()
+        ;
+
+        $translationsForm = $form->get('translations')->all();
+        static::assertEquals('English', $translationsForm['en']->getConfig()->getOptions()['label'], 'Label should be explicitely set');
+        static::assertEquals('Français', $translationsForm['fr']->getConfig()->getOptions()['label'], 'Label should be explicitely set');
+        static::assertEquals(null, $translationsForm['de']->getConfig()->getOptions()['label'], 'Label should default to null');
+    }
+
     protected function getExtensions(): array
     {
         $translationsType = $this->getConfiguredTranslationsType($this->locales, $this->defaultLocale, $this->requiredLocales);

--- a/tests/Form/Type/TranslationsTypeAdvancedTest.php
+++ b/tests/Form/Type/TranslationsTypeAdvancedTest.php
@@ -83,7 +83,7 @@ final class TranslationsTypeAdvancedTest extends TypeTestCase
                 'locale_labels' => [
                     'fr' => 'Français',
                     'en' => 'English',
-                ]
+                ],
             ])
             ->add('save', SubmitType::class)
             ->getForm()
@@ -92,7 +92,7 @@ final class TranslationsTypeAdvancedTest extends TypeTestCase
         $translationsForm = $form->get('translations')->all();
         static::assertEquals('English', $translationsForm['en']->getConfig()->getOptions()['label'], 'Label should be explicitely set');
         static::assertEquals('Français', $translationsForm['fr']->getConfig()->getOptions()['label'], 'Label should be explicitely set');
-        static::assertEquals(null, $translationsForm['de']->getConfig()->getOptions()['label'], 'Label should default to null');
+        static::assertNull($translationsForm['de']->getConfig()->getOptions()['label'], 'Label should default to null');
     }
 
     protected function getExtensions(): array


### PR DESCRIPTION
### Fixed

Tab labels are now translatable / can be tailored.

## To do

- [x] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note

## Documentation

You may now set labels for each tab by adding a `locale_labels` array to the `TranslationsType` form type, like so:

```php
$form = $this->factory->createBuilder(FormType::class, new Product())
    ->add('translations', TranslationsType::class, [
        'locale_labels' => [
            'fr' => 'Français',
            'en' => 'English',
        ],
    ])
    ->add('save', SubmitType::class)
    ->getForm()
;
```

If a label is not set here (in this examplen `de` for instance), its value will default to null and the previous behaviour will kick-in (_the template with capitalize the locale name_).

Hence, this does not introduce any breaking change and no change of defaults, and seems perfectly safe.

As the `trans` filter is used in the templates, you can also use translation keys directly here:

```php
$form = $this->factory->createBuilder(FormType::class, new Product())
    ->add('translations', TranslationsType::class, [
        'locale_labels' => [
            'fr' => 'admin.language.fr.tab_title',
            'en' => 'admin.language.en.tab_title',
        ],
    ])
    ->add('save', SubmitType::class)
    ->getForm()
;
```