### PR TITLE
Allow Symfony 6.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out the documentation on the [official website](http://a2lix.fr/bundles/tr
 
 * `0.x` & `1.x` are old versions not maintained anymore.
 * `2.x` is an old version with low requirements (PHP5.4+/7+, Symfony2.3+/3.0+/4.0+). It is compatible with [Gedmo](https://github.com/Atlantic18/DoctrineExtensions/blob/master/doc/translatable.md), [KnpLabs](https://github.com/KnpLabs/DoctrineBehaviors#translatable), [A2lix](https://github.com/a2lix/I18nDoctrineBundle) and [Prezent](https://github.com/Prezent/doctrine-translatable-bundle)
-* `3.x` is a rethinked version that depends on [AutoFormBundle](https://github.com/a2lix/AutoFormBundle) and has higher requirements (PHP7.2+, Symfony3.4+/4.3+/5.0+). It is compatible with [KnpLabs](https://github.com/KnpLabs/DoctrineBehaviors#translatable), [A2lix](https://github.com/a2lix/I18nDoctrineBundle) and [Prezent](https://github.com/Prezent/doctrine-translatable-bundle)
+* `3.x` is a rethinked version that depends on [AutoFormBundle](https://github.com/a2lix/AutoFormBundle) and has higher requirements (PHP7.2+, Symfony3.4+/4.3+/5.0+/6.0+). It is compatible with [KnpLabs](https://github.com/KnpLabs/DoctrineBehaviors#translatable), [A2lix](https://github.com/a2lix/I18nDoctrineBundle) and [Prezent](https://github.com/Prezent/doctrine-translatable-bundle)
 
 ## Contribution help
 

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
     "require": {
         "php": ">=7.2",
         "a2lix/auto-form-bundle": "^0.2|^0.3",
-        "symfony/config": "^3.4.30|^4.3|^5.0",
-        "symfony/dependency-injection": "^3.4.30|^4.3|^5.0",
-        "symfony/doctrine-bridge": "^3.4.30|^4.3|^5.0",
-        "symfony/event-dispatcher": "^3.4.30|^4.3|^5.0",
-        "symfony/form": "^3.4.30|^4.3|^5.0",
-        "symfony/http-foundation": "^3.4.30|^4.3|^5.0",
-        "symfony/http-kernel": "^3.4.30|^4.3|^5.0",
-        "symfony/options-resolver": "^3.4.30|^4.3|^5.0"
+        "symfony/config": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/dependency-injection": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/doctrine-bridge": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/event-dispatcher": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/form": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/http-foundation": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/http-kernel": "^3.4.30|^4.3|^5.0|^6.0",
+        "symfony/options-resolver": "^3.4.30|^4.3|^5.0|^6.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.7",
@@ -46,7 +46,7 @@
         "phpstan/phpstan": "^1.2.0",
         "symfony/cache": "^5.4",
         "symfony/phpunit-bridge": "^6.0",
-        "symfony/validator": "^3.4.30|^4.3|^5.0",
+        "symfony/validator": "^3.4.30|^4.3|^5.0|^6.0",
         "vimeo/psalm": "^4.15"
     },
     "suggest": {


### PR DESCRIPTION
This PR bumps the dependencies in `composer.json` to allow for Symfony 6.0+