### PR TITLE
:bug: Fix form validation when locale is required (knp behaviors)

### DIFF
--- a/src/Form/EventListener/TranslationsFormsListener.php
+++ b/src/Form/EventListener/TranslationsFormsListener.php
@@ -43,11 +43,14 @@ class TranslationsFormsListener implements EventSubscriberInterface
 
     public function submit(FormEvent $event): void
     {
+        $form = $event->getForm();
+        $formOptions = $form->getConfig()->getOptions();
+
         $data = $event->getData();
 
         foreach ($data as $locale => $translation) {
             // Remove useless Translation object
-            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty()) // Knp
+            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty() && !\in_array($locale, $formOptions['required_locales'], true)) // Knp
                 || empty($translation) // Default
             ) {
                 $data->removeElement($translation);

--- a/src/Form/EventListener/TranslationsListener.php
+++ b/src/Form/EventListener/TranslationsListener.php
@@ -68,11 +68,14 @@ class TranslationsListener implements EventSubscriberInterface
 
     public function submit(FormEvent $event): void
     {
+        $form = $event->getForm();
+        $formOptions = $form->getConfig()->getOptions();
+
         $data = $event->getData();
 
         foreach ($data as $locale => $translation) {
             // Remove useless Translation object
-            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty()) // Knp
+            if ((method_exists($translation, 'isEmpty') && $translation->isEmpty() && !\in_array($locale, $formOptions['required_locales'], true)) // Knp
                 || empty($translation) // Default
             ) {
                 $data->removeElement($translation);


### PR DESCRIPTION
I am targeting master because a tag 3.0.11 will be probably needed. And to be honest Iam not sure which branch to target, maybe the version 2 is relevant (but automatic merge was not possible). Let me know how I can help. I think the subject of this PR is very important and Iam ready to follow rules and modify it in order to see it merged. Thank you for your time.

Closes #361
Closes #356


```markdown
## Changelog

Fix form validation for required locales.

### Fixed

Form validation for required locales.

## To do

Check if this fix is only relevant when using knp behaviors or if it can be applied globally.

## Subject

A check is added for required locale when submiting the form, the element is not removed if the locale is required in order to trigger the "NotBlank" constraint. Otherwise, there is no validation (can submit all fields being empty).
```