### PR TITLE
Add support for DTO objects disconnected from Doctrine entities

### DIFF
--- a/tests/Fixtures/DTO/Form/ProductTranslationType.php
+++ b/tests/Fixtures/DTO/Form/ProductTranslationType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TranslationFormBundle package.
+ *
+ * (c) David ALLIX <http://a2lix.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Tests\Fixtures\DTO\Form;
+
+use A2lix\TranslationFormBundle\Tests\Fixtures\DTO\ProductTranslation;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProductTranslationType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title')
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ProductTranslation::class,
+        ]);
+    }
+}

--- a/tests/Fixtures/DTO/Product.php
+++ b/tests/Fixtures/DTO/Product.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TranslationFormBundle package.
+ *
+ * (c) David ALLIX <http://a2lix.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Tests\Fixtures\DTO;
+
+class Product
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var array<string, ProductTranslation>
+     */
+    public $translations = [];
+
+    /**
+     * @var string
+     */
+    public $url;
+}

--- a/tests/Fixtures/DTO/ProductTranslation.php
+++ b/tests/Fixtures/DTO/ProductTranslation.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TranslationFormBundle package.
+ *
+ * (c) David ALLIX <http://a2lix.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Tests\Fixtures\DTO;
+
+class ProductTranslation
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $locale;
+
+    /**
+     * @var string|null
+     */
+    protected $title;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $locale): self
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Entity/MediaLocalize.php
+++ b/tests/Fixtures/Entity/MediaLocalize.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace A2lix\TranslationFormBundle\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Knp\DoctrineBehaviors\Model\Translatable\TranslationTrait;
 
 /**
  * @ORM\Entity
  */
 class MediaLocalize
 {
+    use TranslationTrait;
+
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")

--- a/tests/Fixtures/Entity/Product.php
+++ b/tests/Fixtures/Entity/Product.php
@@ -50,7 +50,7 @@ class Product
     protected $medias;
 
     /**
-     * @ORM\OneToMany(targetEntity="ProductTranslation", mappedBy="object", indexBy="locale", cascade={"all"}, orphanRemoval=true)
+     * @ORM\OneToMany(targetEntity="ProductTranslation", mappedBy="translatable", indexBy="locale", cascade={"all"}, orphanRemoval=true)
      */
     protected $translations;
 

--- a/tests/Form/Type/TranslationsFormsTypeSimpleDTOTest.php
+++ b/tests/Form/Type/TranslationsFormsTypeSimpleDTOTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TranslationFormBundle package.
+ *
+ * (c) David ALLIX <http://a2lix.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace A2lix\TranslationFormBundle\Tests\Form\Type;
+
+use A2lix\TranslationFormBundle\Form\Type\TranslationsFormsType;
+use A2lix\TranslationFormBundle\Tests\Fixtures\DTO\Form\ProductTranslationType;
+use A2lix\TranslationFormBundle\Tests\Fixtures\DTO\Product;
+use A2lix\TranslationFormBundle\Tests\Fixtures\DTO\ProductTranslation;
+use A2lix\TranslationFormBundle\Tests\Form\TypeTestCase;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\PreloadedExtension;
+
+/**
+ * @internal
+ */
+final class TranslationsFormsTypeSimpleDTOTest extends TypeTestCase
+{
+    protected $locales = ['en', 'fr', 'de'];
+    protected $defaultLocale = 'en';
+    protected $requiredLocales = ['en', 'fr'];
+
+    /**
+     * @dataProvider provideEmptyDETranslationCases
+     */
+    public function testEmptyTranslation(array $formData, Product $productExpected): void
+    {
+        $form = $this->factory->createBuilder(FormType::class, new Product())
+            ->add('translations', TranslationsFormsType::class, [
+                'form_type' => ProductTranslationType::class,
+            ])
+            ->getForm()
+        ;
+
+        $form->submit($formData);
+        static::assertTrue($form->isSynchronized());
+        static::assertEquals($productExpected, $form->getData());
+    }
+
+    public function provideEmptyDETranslationCases(): iterable
+    {
+        $product = new Product();
+        $product->translations['en'] = (new ProductTranslation())
+            ->setTitle('title en')
+            ->setLocale('en')
+        ;
+        $product->translations['fr'] = (new ProductTranslation())
+            ->setTitle('title fr')
+            ->setLocale('fr')
+        ;
+
+        yield 'Translation DE is "null"' => [
+            [
+                'translations' => [
+                    'en' => [
+                        'title' => 'title en',
+                    ],
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => null,
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation DE is an empty string' => [
+            [
+                'translations' => [
+                    'en' => [
+                        'title' => 'title en',
+                    ],
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => '',
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation DE is "false"' => [
+            [
+                'translations' => [
+                    'en' => [
+                        'title' => 'title en',
+                    ],
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => false,
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation DE does\'t exist' => [
+            [
+                'translations' => [
+                    'en' => [
+                        'title' => 'title en',
+                    ],
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                ],
+            ],
+            $product,
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmptyENTranslationCases
+     */
+    public function testEmptyAndRequiredTranslation(array $formData, Product $productExpected): void
+    {
+        $form = $this->factory->createBuilder(FormType::class, new Product())
+            ->add('translations', TranslationsFormsType::class, [
+                'form_type' => ProductTranslationType::class,
+            ])
+            ->getForm()
+        ;
+
+        $form->submit($formData);
+        static::assertTrue($form->isSynchronized());
+        static::assertEquals($productExpected, $form->getData());
+    }
+
+    public function provideEmptyENTranslationCases(): iterable
+    {
+        $product = new Product();
+        $product->translations['en'] = (new ProductTranslation())
+            ->setLocale('en')
+        ;
+        $product->translations['fr'] = (new ProductTranslation())
+            ->setTitle('title fr')
+            ->setLocale('fr')
+        ;
+        $product->translations['de'] = (new ProductTranslation())
+            ->setTitle('title de')
+            ->setLocale('de')
+        ;
+
+        yield 'Translation EN is "null"' => [
+            [
+                'translations' => [
+                    'en' => null,
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => [
+                        'title' => 'title de',
+                    ],
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation EN is an empty string' => [
+            [
+                'translations' => [
+                    'en' => null,
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => [
+                        'title' => 'title de',
+                    ],
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation EN is "false"' => [
+            [
+                'translations' => [
+                    'en' => false,
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => [
+                        'title' => 'title de',
+                    ],
+                ],
+            ],
+            $product,
+        ];
+
+        yield 'Translation EN does\'t exist' => [
+            [
+                'translations' => [
+                    'fr' => [
+                        'title' => 'title fr',
+                    ],
+                    'de' => [
+                        'title' => 'title de',
+                    ],
+                ],
+            ],
+            $product,
+        ];
+    }
+
+    protected function getExtensions(): array
+    {
+        $translationsFormsType = $this->getConfiguredTranslationsFormsType($this->locales, $this->defaultLocale, $this->requiredLocales);
+
+        return [new PreloadedExtension([
+            $translationsFormsType,
+        ], [])];
+    }
+}

--- a/tests/Form/Type/TranslationsFormsTypeSimpleTest.php
+++ b/tests/Form/Type/TranslationsFormsTypeSimpleTest.php
@@ -162,6 +162,98 @@ final class TranslationsFormsTypeSimpleTest extends TypeTestCase
         }
     }
 
+    public function testEmptyTranslation(): void
+    {
+        $form = $this->factory->createBuilder(FormType::class, new Product())
+            ->add('url')
+            ->add('medias', TranslationsFormsType::class, [
+                'form_type' => MediaLocalizeType::class,
+            ])
+            ->add('save', SubmitType::class)
+            ->getForm()
+        ;
+
+        $mediaEn = new MediaLocalize();
+        $mediaEn->setLocale('en')
+            ->setUrl('http://en')
+            ->setDescription('desc en')
+        ;
+        $mediaFr = new MediaLocalize();
+        $mediaFr->setLocale('fr')
+            ->setUrl('http://fr')
+            ->setDescription('desc fr')
+        ;
+
+        $product = new Product();
+        $product->setUrl('a2lix.fr')
+            ->addMedia($mediaEn)
+            ->addMedia($mediaFr)
+        ;
+
+        $formData = [
+            'url' => 'a2lix.fr',
+            'medias' => [
+                'en' => [
+                    'url' => 'http://en',
+                    'description' => 'desc en',
+                ],
+                'fr' => [
+                    'url' => 'http://fr',
+                    'description' => 'desc fr',
+                ],
+                'de' => [
+                    'url' => '',
+                    'description' => '',
+                ],
+            ],
+        ];
+
+        $form->submit($formData);
+        static::assertTrue($form->isSynchronized());
+        static::assertEquals($product, $form->getData());
+    }
+
+    public function testEmptyAndRequiredTranslation(): void
+    {
+        $form = $this->factory->createBuilder(FormType::class, new Product())
+            ->add('url')
+            ->add('medias', TranslationsFormsType::class, [
+                'form_type' => MediaLocalizeType::class,
+            ])
+            ->add('save', SubmitType::class)
+            ->getForm()
+        ;
+
+        $mediaEn = new MediaLocalize();
+        $mediaEn->setLocale('en');
+
+        $mediaFr = new MediaLocalize();
+        $mediaFr->setLocale('fr')
+            ->setUrl('http://fr')
+            ->setDescription('desc fr')
+        ;
+
+        $product = new Product();
+        $product->setUrl('a2lix.fr')
+            ->addMedia($mediaEn)
+            ->addMedia($mediaFr)
+        ;
+
+        $formData = [
+            'url' => 'a2lix.fr',
+            'medias' => [
+                'fr' => [
+                    'url' => 'http://fr',
+                    'description' => 'desc fr',
+                ],
+            ],
+        ];
+
+        $form->submit($formData);
+        static::assertTrue($form->isSynchronized());
+        static::assertEquals($product, $form->getData());
+    }
+
     protected function getExtensions(): array
     {
         $translationsFormsType = $this->getConfiguredTranslationsFormsType($this->locales, $this->defaultLocale, $this->requiredLocales);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting this branch, because this is a feature without a BC-break.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
Add support for DTO objects disconnected from Doctrine entities
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

It is common to want to use forms on objects that are disconnected from the doctrine entities. In this case, it is not necessary to use a doctrine collection, a simple array can be enough. 
