### PR TITLE
fix: using href="#*" spams browser history

### DIFF
--- a/src/Resources/views/bootstrap_4_layout.html.twig
+++ b/src/Resources/views/bootstrap_4_layout.html.twig
@@ -7,11 +7,11 @@
             {% set locale = translationsFields.vars.name %}
 
             <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+                <div data-target="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
-                </a>
+                </div>
             </li>
         {% endfor %}
         </ul>

--- a/src/Resources/views/bootstrap_5_layout.html.twig
+++ b/src/Resources/views/bootstrap_5_layout.html.twig
@@ -7,11 +7,11 @@
             {% set locale = translationsFields.vars.name %}
 
             <li class="nav-item">
-                <a href="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-bs-toggle="tab" role="tab">
+                <div data-bs-target="#{{ translationsFields.vars.id }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-bs-toggle="tab" role="tab">
                     {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                     {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                     {% if translationsFields.vars.required %}*{% endif %}
-                </a>
+                </div>
             </li>
         {% endfor %}
         </ul>

--- a/src/Resources/views/macros_bootstrap_4.html.twig
+++ b/src/Resources/views/macros_bootstrap_4.html.twig
@@ -14,11 +14,11 @@ Example:
                 {% set locale = translationsFields.vars.name %}
 
                 <li class="nav-item">
-                    <a href="#{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
+                    <div data-target="#{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-toggle="tab" role="tab">
                         {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                         {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                         {% if translationsFields.vars.required %}*{% endif %}
-                    </a>
+                    </div>
                 </li>
             {% endfor %}
         </ul>

--- a/src/Resources/views/macros_bootstrap_5.html.twig
+++ b/src/Resources/views/macros_bootstrap_5.html.twig
@@ -14,11 +14,11 @@ Example:
                 {% set locale = translationsFields.vars.name %}
 
                 <li class="nav-item">
-                    <a href="#{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-bs-toggle="tab" role="tab">
+                    <div data-bs-target="#{{ translationsFields.vars.id }}_{{ fieldsNames|join('_') }}_a2lix_translations-fields" class="nav-link {% if app.request.locale == locale %}active{% endif %}" data-bs-toggle="tab" role="tab">
                         {{ translationsFields.vars.label|default(locale|humanize)|trans }}
                         {% if form.vars.default_locale == locale %}{{ '[Default]'|trans }}{% endif %}
                         {% if translationsFields.vars.required %}*{% endif %}
-                    </a>
+                    </div>
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
I am targeting this branch, because i don't see these files in 2.x.

Closes #389

## Changelog

```markdown

### Added

### Changed
Replaced `<a href="*">` to `<div data-bs-target="*">`

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
