### PR TITLE
added included_fields option to TranslationsType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "symfony/http-kernel": "^5.4.30|^6.3|^7.0",
         "symfony/options-resolver": "^5.4.30|^6.3|^7.0"
     },
+    "conflict": {
+        "a2lix/auto-form-bundle": "<0.4.8"
+    },
     "require-dev": {
         "doctrine/orm": "^2.15",
         "friendsofphp/php-cs-fixer": "^3.45",

--- a/src/Form/EventListener/TranslationsListener.php
+++ b/src/Form/EventListener/TranslationsListener.php
@@ -58,6 +58,7 @@ class TranslationsListener implements EventSubscriberInterface
                 'block_name' => ('field' === $formOptions['theming_granularity']) ? 'locale' : null,
                 'fields' => $fieldsOptions[$locale],
                 'excluded_fields' => $formOptions['excluded_fields'],
+                'included_fields' => $formOptions['included_fields'],
             ]);
         }
     }

--- a/src/Form/Type/TranslationsType.php
+++ b/src/Form/Type/TranslationsType.php
@@ -52,6 +52,7 @@ class TranslationsType extends AbstractType
             'theming_granularity' => 'field',
             'fields' => [],
             'excluded_fields' => [],
+            'included_fields' => [],
         ]);
 
         $resolver->setAllowedValues('theming_granularity', ['field', 'locale_field']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
-->
I am targeting master, because it's new feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
Added "included_fields" option to TranslationsType

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
This feature needs this PR in AutoFormBundle https://github.com/a2lix/AutoFormBundle/pull/44