### PR TITLE
Allow symfony/ux-twig-component ^3.0 alongside ^2.31

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/intl": "^7.4|^8.0",
         "symfony/options-resolver": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
-        "symfony/ux-twig-component": "^2.31"
+        "symfony/ux-twig-component": "^2.31|^3.0"
     },
     "require-dev": {
         "doctrine/orm": "^3.5.8",


### PR DESCRIPTION
## Problem
Composer fails when the application requires `symfony/ux-twig-component` 3.x while this bundle only allows `^2.31` (e.g. conflict with root `3.0.0`).

## Solution
Widen the constraint to `^2.31|^3.0` in `composer.json`.

## Notes
The bundle’s `LocaleSwitcher` is registered via the `twig.component` service tag and a simple Twig template; it does not rely on APIs removed in ux-twig-component 3.x.

I have not run the full test suite in this environment; happy to adjust if maintainers want CI or additional compatibility checks.